### PR TITLE
Check job pod status in addition to job status to update CR status

### DIFF
--- a/api/v1alpha1/flinkcluster_types.go
+++ b/api/v1alpha1/flinkcluster_types.go
@@ -49,11 +49,13 @@ var ClusterComponentState = struct {
 
 // JobState defines states for a Flink job.
 var JobState = struct {
+	Pending   string
 	Running   string
 	Succeeded string
 	Failed    string
 	Unknown   string
 }{
+	Pending:   "Pending",
 	Running:   "Running",
 	Succeeded: "Succeeded",
 	Failed:    "Failed",

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -47,6 +47,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - get

--- a/controllers/flinkcluster_controller.go
+++ b/controllers/flinkcluster_controller.go
@@ -39,6 +39,8 @@ type FlinkClusterReconciler struct {
 // +kubebuilder:rbac:groups=flinkoperator.k8s.io,resources=flinkclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -46,13 +46,12 @@ func getDesiredClusterState(
 	// The cluster has been deleted, all resources should be cleaned up.
 	if cluster == nil {
 		return _DesiredClusterState{}
-	} else {
-		return _DesiredClusterState{
-			jmDeployment: getDesiredJobManagerDeployment(cluster),
-			jmService:    getDesiredJobManagerService(cluster),
-			tmDeployment: getDesiredTaskManagerDeployment(cluster),
-			job:          getDesiredJob(cluster),
-		}
+	}
+	return _DesiredClusterState{
+		jmDeployment: getDesiredJobManagerDeployment(cluster),
+		jmService:    getDesiredJobManagerService(cluster),
+		tmDeployment: getDesiredTaskManagerDeployment(cluster),
+		job:          getDesiredJob(cluster),
 	}
 }
 

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -313,11 +313,6 @@ func getDesiredJob(
 		return nil
 	}
 
-	if flinkCluster.Status.State ==
-		flinkoperatorv1alpha1.ClusterState.Creating {
-		return nil
-	}
-
 	var imageSpec = flinkCluster.Spec.ImageSpec
 	var jobManagerSpec = flinkCluster.Spec.JobManagerSpec
 	var clusterNamespace = flinkCluster.ObjectMeta.Namespace

--- a/controllers/flinkcluster_observer.go
+++ b/controllers/flinkcluster_observer.go
@@ -78,10 +78,9 @@ func (observer *_ClusterStateObserver) observe(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get the cluster resource")
 			return err
-		} else {
-			log.Info("Observed cluster", "cluster", "nil")
-			observedCluster = nil
 		}
+		log.Info("Observed cluster", "cluster", "nil")
+		observedCluster = nil
 	} else {
 		log.Info("Observed cluster", "cluster", *observedCluster)
 		observedState.cluster = observedCluster
@@ -94,10 +93,9 @@ func (observer *_ClusterStateObserver) observe(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get JobManager deployment")
 			return err
-		} else {
-			log.Info("Observed JobManager deployment", "state", "nil")
-			observedJmDeployment = nil
 		}
+		log.Info("Observed JobManager deployment", "state", "nil")
+		observedJmDeployment = nil
 	} else {
 		log.Info("Observed JobManager deployment", "state", *observedJmDeployment)
 		observedState.jmDeployment = observedJmDeployment
@@ -110,10 +108,9 @@ func (observer *_ClusterStateObserver) observe(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get JobManager service")
 			return err
-		} else {
-			log.Info("Observed JobManager service", "state", "nil")
-			observedJmService = nil
 		}
+		log.Info("Observed JobManager service", "state", "nil")
+		observedJmService = nil
 	} else {
 		log.Info("Observed JobManager service", "state", *observedJmService)
 		observedState.jmService = observedJmService
@@ -126,10 +123,9 @@ func (observer *_ClusterStateObserver) observe(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get TaskManager deployment")
 			return err
-		} else {
-			log.Info("Observed TaskManager deployment", "state", "nil")
-			observedTmDeployment = nil
 		}
+		log.Info("Observed TaskManager deployment", "state", "nil")
+		observedTmDeployment = nil
 	} else {
 		log.Info("Observed TaskManager deployment", "state", *observedTmDeployment)
 		observedState.tmDeployment = observedTmDeployment
@@ -159,10 +155,9 @@ func (observer *_ClusterStateObserver) observeJob(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get job")
 			return err
-		} else {
-			log.Info("Observed job", "state", "nil")
-			observedJob = nil
 		}
+		log.Info("Observed job", "state", "nil")
+		observedJob = nil
 	} else {
 		log.Info("Observed job", "state", *observedJob)
 		observedState.job = observedJob
@@ -175,10 +170,9 @@ func (observer *_ClusterStateObserver) observeJob(
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get job pods")
 			return err
-		} else {
-			log.Info("Observed job pods", "pods", "nil")
-			observedJobPods = nil
 		}
+		log.Info("Observed job pods", "pods", "nil")
+		observedJobPods = nil
 	} else {
 		log.Info("Observed job pods", "pods", observedJobPods.Items)
 		if len(observedJobPods.Items) == 1 {
@@ -317,7 +311,8 @@ func (observer *_ClusterStateObserver) observeJobResource(
 		observedJob)
 }
 
-func (observer *_ClusterStateObserver) observeJobPods(observedJobPod *corev1.PodList) error {
+func (observer *_ClusterStateObserver) observeJobPods(
+	observedJobPod *corev1.PodList) error {
 	var clusterName = observer.request.Name
 	var jobName = getJobName(observer.request.Name)
 	var inNamespace = client.InNamespace(observer.request.Namespace)
@@ -326,5 +321,7 @@ func (observer *_ClusterStateObserver) observeJobPods(observedJobPod *corev1.Pod
 		"cluster":  clusterName,
 		"job-name": jobName,
 	}
-	return observer.k8sClient.List(context.Background(), observedJobPod, inNamespace, matchingLabels)
+	var jobPods = observer.k8sClient.List(
+		observer.context, observedJobPod, inNamespace, matchingLabels)
+	return jobPods
 }

--- a/controllers/flinkcluster_observer.go
+++ b/controllers/flinkcluster_observer.go
@@ -49,6 +49,7 @@ type _ObservedClusterState struct {
 	jmService    *corev1.Service
 	tmDeployment *appsv1.Deployment
 	job          *batchv1.Job
+	jobPod       *corev1.Pod
 	flinkJobID   *string
 }
 
@@ -135,35 +136,78 @@ func (observer *_ClusterStateObserver) observe(
 	}
 
 	// (Optional) job.
-	var observedJob *batchv1.Job
-	if observedState.cluster != nil && observedState.cluster.Spec.JobSpec != nil {
-		observedJob = new(batchv1.Job)
-		err = observer.observeJob(observedJob)
-		if err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				log.Error(err, "Failed to get job")
-				return err
-			} else {
-				log.Info("Observed job", "state", "nil")
-				observedJob = nil
-			}
+	err = observer.observeJob(observedState)
+
+	return err
+}
+
+func (observer *_ClusterStateObserver) observeJob(
+	observedState *_ObservedClusterState) error {
+	var err error
+	var log = observer.log
+
+	// Either the cluster has been deleted or it is a session cluster.
+	if observedState.cluster == nil ||
+		observedState.cluster.Spec.JobSpec == nil {
+		return nil
+	}
+
+	// Job resource.
+	var observedJob = new(batchv1.Job)
+	err = observer.observeJobResource(observedJob)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Failed to get job")
+			return err
 		} else {
-			log.Info("Observed job", "state", *observedJob)
-			observedState.job = observedJob
+			log.Info("Observed job", "state", "nil")
+			observedJob = nil
+		}
+	} else {
+		log.Info("Observed job", "state", *observedJob)
+		observedState.job = observedJob
+	}
+
+	// Job pod.
+	var observedJobPods = new(corev1.PodList)
+	err = observer.observeJobPods(observedJobPods)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Failed to get job pods")
+			return err
+		} else {
+			log.Info("Observed job pods", "pods", "nil")
+			observedJobPods = nil
+		}
+	} else {
+		log.Info("Observed job pods", "pods", observedJobPods.Items)
+		if len(observedJobPods.Items) == 1 {
+			observedState.jobPod = &observedJobPods.Items[0]
+		} else if len(observedJobPods.Items) > 1 {
+			// Should never be true unless the user manually created a pod
+			// which matches the labels.
+			return fmt.Errorf(
+				"Exactly one job pod is expected, but found more: %p",
+				observedJobPods.Items)
 		}
 	}
 
-	// (Optional) get Flink job ID.
-	if observedCluster != nil && observedJob != nil && observedJmService != nil {
+	// Flink job ID.
+	var isJobCreated = observedJob != nil &&
+		observedState.jobPod != nil &&
+		observedState.jobPod.Status.Phase != corev1.PodPhase("Pending")
+	if isJobCreated {
 		var url = fmt.Sprintf(
 			"http://%s.%s.svc.cluster.local:%d/jobs",
-			observedJmService.GetName(),
-			observedJmService.GetNamespace(),
-			*observedCluster.Spec.JobManagerSpec.Ports.UI)
+			observedState.jmService.GetName(),
+			observedState.jmService.GetNamespace(),
+			*observedState.cluster.Spec.JobManagerSpec.Ports.UI)
 		var flinkJobID = observer.getFlinkJobID(url)
 		if flinkJobID != nil {
 			observedState.flinkJobID = flinkJobID
 		}
+	} else {
+		log.Info("Skip getting Flink job ID")
 	}
 
 	return nil
@@ -259,7 +303,7 @@ func (observer *_ClusterStateObserver) observeJobManagerService(
 		observedService)
 }
 
-func (observer *_ClusterStateObserver) observeJob(
+func (observer *_ClusterStateObserver) observeJobResource(
 	observedJob *batchv1.Job) error {
 	var clusterNamespace = observer.request.Namespace
 	var clusterName = observer.request.Name
@@ -271,4 +315,16 @@ func (observer *_ClusterStateObserver) observeJob(
 			Name:      getJobName(clusterName),
 		},
 		observedJob)
+}
+
+func (observer *_ClusterStateObserver) observeJobPods(observedJobPod *corev1.PodList) error {
+	var clusterName = observer.request.Name
+	var jobName = getJobName(observer.request.Name)
+	var inNamespace = client.InNamespace(observer.request.Namespace)
+	var matchingLabels client.MatchingLabels = map[string]string{
+		"app":      "flink",
+		"cluster":  clusterName,
+		"job-name": jobName,
+	}
+	return observer.k8sClient.List(context.Background(), observedJobPod, inNamespace, matchingLabels)
 }

--- a/controllers/flinkcluster_updater.go
+++ b/controllers/flinkcluster_updater.go
@@ -66,9 +66,9 @@ func (updater *_ClusterStatusUpdater) updateClusterStatusIfChanged() error {
 			"new", newStatus)
 		newStatus.LastUpdateTime = time.Now().Format(time.RFC3339)
 		return updater.updateClusterStatus(newStatus)
-	} else {
-		updater.log.Info("No status change", "state", currentStatus.State)
 	}
+
+	updater.log.Info("No status change", "state", currentStatus.State)
 	return nil
 }
 
@@ -79,8 +79,10 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 
 	var totalComponents = 0
 	if updater.observedState.cluster.Spec.JobSpec != nil {
+		// jmDeployment, jmService, tmDeployment, job
 		totalComponents = 4
 	} else {
+		// jmDeployment, jmService, tmDeployment
 		totalComponents = 3
 	}
 

--- a/controllers/flinkcluster_updater.go
+++ b/controllers/flinkcluster_updater.go
@@ -74,9 +74,15 @@ func (updater *_ClusterStatusUpdater) updateClusterStatusIfChanged() error {
 
 func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha1.FlinkClusterStatus {
 	var status = flinkoperatorv1alpha1.FlinkClusterStatus{}
-	var totalComponents = 3
-	var readyComponents = 0
+	var runningComponents = 0
 	var recordedClusterStatus = &updater.observedState.cluster.Status
+
+	var totalComponents = 0
+	if updater.observedState.cluster.Spec.JobSpec != nil {
+		totalComponents = 4
+	} else {
+		totalComponents = 3
+	}
 
 	// JobManager deployment.
 	var observedJmDeployment = updater.observedState.jmDeployment
@@ -92,7 +98,7 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 		} else {
 			status.Components.JobManagerDeployment.State =
 				flinkoperatorv1alpha1.ClusterComponentState.Ready
-			readyComponents++
+			runningComponents++
 		}
 	} else if recordedClusterStatus.Components.JobManagerDeployment.Name != "" {
 		status.Components.JobManagerDeployment =
@@ -109,14 +115,14 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 		if observedJmService.Spec.Type == corev1.ServiceTypeClusterIP {
 			if observedJmService.Spec.ClusterIP != "" {
 				state = flinkoperatorv1alpha1.ClusterComponentState.Ready
-				readyComponents++
+				runningComponents++
 			} else {
 				state = flinkoperatorv1alpha1.ClusterComponentState.NotReady
 			}
 		} else if observedJmService.Spec.Type == corev1.ServiceTypeLoadBalancer {
 			if len(observedJmService.Status.LoadBalancer.Ingress) > 0 {
 				state = flinkoperatorv1alpha1.ClusterComponentState.Ready
-				readyComponents++
+				runningComponents++
 			} else {
 				state = flinkoperatorv1alpha1.ClusterComponentState.NotReady
 			}
@@ -148,7 +154,7 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 		} else {
 			status.Components.TaskManagerDeployment.State =
 				flinkoperatorv1alpha1.ClusterComponentState.Ready
-			readyComponents++
+			runningComponents++
 		}
 	} else if recordedClusterStatus.Components.TaskManagerDeployment.Name != "" {
 		status.Components.TaskManagerDeployment =
@@ -165,7 +171,15 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 		status.Components.Job = new(flinkoperatorv1alpha1.JobStatus)
 		status.Components.Job.Name = observedJob.ObjectMeta.Name
 		if observedJob.Status.Active > 0 {
-			status.Components.Job.State = flinkoperatorv1alpha1.JobState.Running
+			var observedJobPod = updater.observedState.jobPod
+			// When job status is Active, it is possible that the pod is still
+			// Pending.
+			if observedJobPod != nil && observedJobPod.Status.Phase == "Pending" {
+				status.Components.Job.State = flinkoperatorv1alpha1.JobState.Pending
+			} else {
+				status.Components.Job.State = flinkoperatorv1alpha1.JobState.Running
+				runningComponents++
+			}
 		} else if observedJob.Status.Failed > 0 {
 			status.Components.Job.State = flinkoperatorv1alpha1.JobState.Failed
 			jobFinished = true
@@ -204,14 +218,14 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 	// Derive the next state.
 	switch recordedClusterStatus.State {
 	case "", flinkoperatorv1alpha1.ClusterState.Creating:
-		if readyComponents < totalComponents {
+		if runningComponents < totalComponents {
 			status.State = flinkoperatorv1alpha1.ClusterState.Creating
 		} else {
 			status.State = flinkoperatorv1alpha1.ClusterState.Running
 		}
 	case flinkoperatorv1alpha1.ClusterState.Running,
 		flinkoperatorv1alpha1.ClusterState.Reconciling:
-		if readyComponents < totalComponents {
+		if runningComponents < totalComponents {
 			status.State = flinkoperatorv1alpha1.ClusterState.Reconciling
 		} else if jobFinished {
 			status.State = flinkoperatorv1alpha1.ClusterState.Stopping
@@ -219,7 +233,7 @@ func (updater *_ClusterStatusUpdater) deriveClusterStatus() flinkoperatorv1alpha
 			status.State = flinkoperatorv1alpha1.ClusterState.Running
 		}
 	case flinkoperatorv1alpha1.ClusterState.Stopping:
-		if readyComponents == 0 {
+		if runningComponents == 0 {
 			status.State = flinkoperatorv1alpha1.ClusterState.Stopped
 		} else {
 			status.State = flinkoperatorv1alpha1.ClusterState.Stopping


### PR DESCRIPTION
Job status could be marked as Running when the pod is still pending for
being scheduled, this caused we mark FlinkCluster status as Running when
it is still creating.

Fix #30