### PR TITLE
Re-queue the reconcile after reconciliation failed.

### DIFF
--- a/controllers/flinkcluster_controller.go
+++ b/controllers/flinkcluster_controller.go
@@ -156,7 +156,7 @@ func (handler *_FlinkClusterHandler) Reconcile(
 	if err != nil {
 		log.Error(err, "Failed to reconcile")
 		return ctrl.Result{
-                	RequeueAfter: time.Second,
+                	RequeueAfter: 5 * time.Second,
                 	Requeue:      true,
 		}, err
 	}

--- a/controllers/flinkcluster_controller.go
+++ b/controllers/flinkcluster_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -154,7 +155,10 @@ func (handler *_FlinkClusterHandler) Reconcile(
 	err = reconciler.reconcile()
 	if err != nil {
 		log.Error(err, "Failed to reconcile")
-		return ctrl.Result{}, err
+		return ctrl.Result{
+                	RequeueAfter: time.Second,
+                	Requeue:      true,
+		}, err
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Reconciliation event should be immediately rescheduled if a controller enters an error condition and returns an error in the reconcile method.