### PR TITLE
Fix to parse time format of last savepoint that includes time zone offset

### DIFF
--- a/controllers/flinkcluster_util.go
+++ b/controllers/flinkcluster_util.go
@@ -62,7 +62,7 @@ type TimeConverter struct{}
 // FromString converts string to time.Time.
 func (tc *TimeConverter) FromString(timeStr string) time.Time {
 	timestamp, err := time.Parse(
-		"2006-01-02T15:04:05Z", timeStr)
+		time.RFC3339, timeStr)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse time string: %s", timeStr))
 	}


### PR DESCRIPTION
It seems that we can't parse the time format with time zone offset. RFC3339 layout should be applied when reading as well as when writing savepoint time.

--------------------------------------------


2019-10-24T09:57:27.190+0900	INFO	controllers.FlinkCluster	---------- 4. Take actions ----------	{"cluster": "elan/fcs"}
2019-10-24T09:57:27.190+0900	INFO	controllers.FlinkCluster	Deployment already exists, no action	{"cluster": "elan/fcs", "component": "JobManager"}
2019-10-24T09:57:27.190+0900	INFO	controllers.FlinkCluster	JobManager service already exists, no action	{"cluster": "elan/fcs"}
2019-10-24T09:57:27.190+0900	INFO	controllers.FlinkCluster	Deployment already exists, no action	{"cluster": "elan/fcs", "component": "TaskManager"}
E1024 09:57:27.190395   43338 runtime.go:67] Observed a panic: Failed to parse time string: 2019-10-24T09:57:18+09:00
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/runtime/runtime.go:76
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/runtime/runtime.go:65
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/runtime/runtime.go:51
/usr/local/Cellar/go/1.13.1/libexec/src/runtime/panic.go:679
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_util.go:72
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:407
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:299
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:77
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_controller.go:192
/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_controller.go:73
/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:216
/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:192
/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:171
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
/usr/local/Cellar/go/1.13.1/libexec/src/runtime/asm_amd64.s:1357
panic: Failed to parse time string: 2019-10-24T09:57:18+09:00 [recovered]
	panic: Failed to parse time string: 2019-10-24T09:57:18+09:00

goroutine 268 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/runtime/runtime.go:58 +0x1ae
panic(0x23efd80, 0xc0005f6de0)
	/usr/local/Cellar/go/1.13.1/libexec/src/runtime/panic.go:679 +0x1e0
github.com/googlecloudplatform/flink-operator/controllers.(*TimeConverter).FromString(0xc0006acef7, 0xc000047ec0, 0x19, 0x0, 0x0, 0x0)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_util.go:72 +0x26b
github.com/googlecloudplatform/flink-operator/controllers.(*ClusterReconciler).shouldTakeSavepoint(0xc0006ad730, 0xc000047e00)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:407 +0x1b9
github.com/googlecloudplatform/flink-operator/controllers.(*ClusterReconciler).reconcileJob(0xc0008f5730, 0x0, 0x0, 0x0, 0x0)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:299 +0x2e7
github.com/googlecloudplatform/flink-operator/controllers.(*ClusterReconciler).reconcile(0xc0006ad730, 0x25f5300, 0x0, 0x0, 0x0)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_reconciler.go:77 +0x2bd
github.com/googlecloudplatform/flink-operator/controllers.(*FlinkClusterHandler).reconcile(0xc0006ad8e0, 0xc0000e903c, 0x4, 0xc0000e900c, 0x3, 0xc0005e8e00, 0x0, 0x0, 0x0)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_controller.go:192 +0x10b1
github.com/googlecloudplatform/flink-operator/controllers.(*FlinkClusterReconciler).Reconcile(0xc0005fa210, 0xc0000e903c, 0x4, 0xc0000e900c, 0x3, 0x0, 0x0, 0x0, 0x0)
	/Users/elan/dev/flink-on-k8s-operator/controllers/flinkcluster_controller.go:73 +0x343
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000149220, 0x249fec0, 0xc00061e040, 0x4e6c455354526e00)
	/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:216 +0x22a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000149220, 0xa2f44c00)
	/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:192 +0x144
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000149220)
	/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:171 +0x2d
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00052e480)
	/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152 +0x60
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00052e480, 0x3b9aca00, 0x0, 0xc0000b0a01, 0xc0004f0300)
	/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153 +0xe8
k8s.io/apimachinery/pkg/util/wait.Until(0xc00052e480, 0x3b9aca00, 0xc0004f0300)
	/Users/elan/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start
	/Users/elan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:157 +0x51f

Debugger finished with exit code 0