### PR TITLE
Support restore from last savepoint recorded in job status

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ clusters and jobs.
 * Flink and Hadoop configs and container environment variables
 * Init containers and sidecar containers
 * Remote job jar
+* Configurable namespace to run the operator in
+* Configurable namepsace to watch custom resources in
 * Configurable access scope for JobManager service
 * Taking savepoints periodically
 * Taking savepoints on demand

--- a/main.go
+++ b/main.go
@@ -50,9 +50,15 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var watchNamespace string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(
+		&watchNamespace,
+		"watch-namespace",
+		"",
+		"Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -68,8 +74,9 @@ func main() {
 	}
 
 	err = (&controllers.FlinkClusterReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("FlinkCluster"),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("FlinkCluster"),
+		WatchNamespace: watchNamespace,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "FlinkCluster")


### PR DESCRIPTION
This feature allows users to stop and resume jobs without explicitly
updating the savepoint to restore the job from. The controller
automatically uses the last savepoint recorded in job status. To enable
this feature, the user only needs to provide savepointsDir and set
fromLastSavepoint to true.