### PR TITLE
Calculate Flink JVM heap size

### DIFF
--- a/api/v1alpha1/flinkcluster_default.go
+++ b/api/v1alpha1/flinkcluster_default.go
@@ -64,6 +64,14 @@ func _SetJobManagerDefault(jmSpec *JobManagerSpec) {
 		jmSpec.Ports.UI = new(int32)
 		*jmSpec.Ports.UI = 8081
 	}
+	if jmSpec.MemoryOffHeapMin == nil {
+		jmSpec.MemoryOffHeapMin = new(int32)
+		*jmSpec.MemoryOffHeapMin = 600
+	}
+	if jmSpec.MemoryOffHeapRatio == nil {
+		jmSpec.MemoryOffHeapRatio = new(int32)
+		*jmSpec.MemoryOffHeapRatio = 25
+	}
 }
 
 func _SetTaskManagerDefault(tmSpec *TaskManagerSpec) {
@@ -78,6 +86,14 @@ func _SetTaskManagerDefault(tmSpec *TaskManagerSpec) {
 	if tmSpec.Ports.Query == nil {
 		tmSpec.Ports.Query = new(int32)
 		*tmSpec.Ports.Query = 6125
+	}
+	if tmSpec.MemoryOffHeapMin == nil {
+		tmSpec.MemoryOffHeapMin = new(int32)
+		*tmSpec.MemoryOffHeapMin = 600
+	}
+	if tmSpec.MemoryOffHeapRatio == nil {
+		tmSpec.MemoryOffHeapRatio = new(int32)
+		*tmSpec.MemoryOffHeapRatio = 25
 	}
 }
 

--- a/api/v1alpha1/flinkcluster_default.go
+++ b/api/v1alpha1/flinkcluster_default.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Sets default values for unspecified FlinkCluster properties.
@@ -64,9 +65,8 @@ func _SetJobManagerDefault(jmSpec *JobManagerSpec) {
 		jmSpec.Ports.UI = new(int32)
 		*jmSpec.Ports.UI = 8081
 	}
-	if jmSpec.MemoryOffHeapMin == nil {
-		jmSpec.MemoryOffHeapMin = new(int32)
-		*jmSpec.MemoryOffHeapMin = 600
+	if jmSpec.MemoryOffHeapMin.Format == "" {
+		jmSpec.MemoryOffHeapMin = *resource.NewScaledQuantity(600, 6) // 600MB
 	}
 	if jmSpec.MemoryOffHeapRatio == nil {
 		jmSpec.MemoryOffHeapRatio = new(int32)
@@ -87,9 +87,8 @@ func _SetTaskManagerDefault(tmSpec *TaskManagerSpec) {
 		tmSpec.Ports.Query = new(int32)
 		*tmSpec.Ports.Query = 6125
 	}
-	if tmSpec.MemoryOffHeapMin == nil {
-		tmSpec.MemoryOffHeapMin = new(int32)
-		*tmSpec.MemoryOffHeapMin = 600
+	if tmSpec.MemoryOffHeapMin.Format == "" {
+		tmSpec.MemoryOffHeapMin = *resource.NewScaledQuantity(600, 6) // 600MB
 	}
 	if tmSpec.MemoryOffHeapRatio == nil {
 		tmSpec.MemoryOffHeapRatio = new(int32)

--- a/api/v1alpha1/flinkcluster_default_test.go
+++ b/api/v1alpha1/flinkcluster_default_test.go
@@ -49,6 +49,8 @@ func TestSetDefault(t *testing.T) {
 	var defaultJobNoLoggingToStdout = false
 	var defaultJobRestartPolicy = corev1.RestartPolicy("OnFailure")
 	var defatulJobManagerIngressTLSUse = false
+	var defaultMemoryOffHeapRatio = int32(25)
+	var defaultMemoryOffHeapMin = int32(600)
 	var expectedCluster = FlinkCluster{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
@@ -70,9 +72,11 @@ func TestSetDefault(t *testing.T) {
 					Query: &defaultJmQueryPort,
 					UI:    &defaultJmUIPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
-				Mounts:    nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &defaultMemoryOffHeapRatio,
+				MemoryOffHeapMin:   &defaultMemoryOffHeapMin,
+				Volumes:            nil,
+				Mounts:             nil,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -81,8 +85,10 @@ func TestSetDefault(t *testing.T) {
 					RPC:   &defaultTmRPCPort,
 					Query: &defaultTmQueryPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &defaultMemoryOffHeapRatio,
+				MemoryOffHeapMin:   &defaultMemoryOffHeapMin,
+				Volumes:            nil,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &defaultJobAllowNonRestoredState,
@@ -119,6 +125,8 @@ func TestSetNonDefault(t *testing.T) {
 	var jobNoLoggingToStdout = true
 	var jobRestartPolicy = corev1.RestartPolicy("Never")
 	var jobManagerIngressTLSUse = true
+	var memoryOffHeapRatio = int32(50)
+	var memoryOffHeapMin = int32(1000)
 	var cluster = FlinkCluster{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
@@ -140,9 +148,11 @@ func TestSetNonDefault(t *testing.T) {
 					Query: &jmQueryPort,
 					UI:    &jmUIPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
-				Mounts:    nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+				Volumes:            nil,
+				Mounts:             nil,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -151,8 +161,10 @@ func TestSetNonDefault(t *testing.T) {
 					RPC:   &tmRPCPort,
 					Query: &tmQueryPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+				Volumes:            nil,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &jobAllowNonRestoredState,
@@ -194,9 +206,11 @@ func TestSetNonDefault(t *testing.T) {
 					Query: &jmQueryPort,
 					UI:    &jmUIPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
-				Mounts:    nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+				Volumes:            nil,
+				Mounts:             nil,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -205,8 +219,10 @@ func TestSetNonDefault(t *testing.T) {
 					RPC:   &tmRPCPort,
 					Query: &tmQueryPort,
 				},
-				Resources: corev1.ResourceRequirements{},
-				Volumes:   nil,
+				Resources:          corev1.ResourceRequirements{},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+				Volumes:            nil,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &jobAllowNonRestoredState,

--- a/api/v1alpha1/flinkcluster_default_test.go
+++ b/api/v1alpha1/flinkcluster_default_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 
 	"gotest.tools/assert"
@@ -50,7 +52,7 @@ func TestSetDefault(t *testing.T) {
 	var defaultJobRestartPolicy = corev1.RestartPolicy("OnFailure")
 	var defatulJobManagerIngressTLSUse = false
 	var defaultMemoryOffHeapRatio = int32(25)
-	var defaultMemoryOffHeapMin = int32(600)
+	var defaultMemoryOffHeapMin = resource.MustParse("600M")
 	var expectedCluster = FlinkCluster{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
@@ -74,7 +76,7 @@ func TestSetDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &defaultMemoryOffHeapRatio,
-				MemoryOffHeapMin:   &defaultMemoryOffHeapMin,
+				MemoryOffHeapMin:   defaultMemoryOffHeapMin,
 				Volumes:            nil,
 				Mounts:             nil,
 			},
@@ -87,7 +89,7 @@ func TestSetDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &defaultMemoryOffHeapRatio,
-				MemoryOffHeapMin:   &defaultMemoryOffHeapMin,
+				MemoryOffHeapMin:   defaultMemoryOffHeapMin,
 				Volumes:            nil,
 			},
 			Job: &JobSpec{
@@ -107,7 +109,11 @@ func TestSetDefault(t *testing.T) {
 		Status: FlinkClusterStatus{},
 	}
 
-	assert.DeepEqual(t, cluster, expectedCluster)
+	assert.DeepEqual(
+		t,
+		cluster,
+		expectedCluster,
+		cmpopts.IgnoreUnexported(resource.Quantity{}))
 }
 
 // Tests non-default values are not overwritten unexpectedly.
@@ -126,7 +132,7 @@ func TestSetNonDefault(t *testing.T) {
 	var jobRestartPolicy = corev1.RestartPolicy("Never")
 	var jobManagerIngressTLSUse = true
 	var memoryOffHeapRatio = int32(50)
-	var memoryOffHeapMin = int32(1000)
+	var memoryOffHeapMin = resource.MustParse("600M")
 	var cluster = FlinkCluster{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
@@ -150,7 +156,7 @@ func TestSetNonDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 				Mounts:             nil,
 			},
@@ -163,7 +169,7 @@ func TestSetNonDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 			},
 			Job: &JobSpec{
@@ -208,7 +214,7 @@ func TestSetNonDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 				Mounts:             nil,
 			},
@@ -221,7 +227,7 @@ func TestSetNonDefault(t *testing.T) {
 				},
 				Resources:          corev1.ResourceRequirements{},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 			},
 			Job: &JobSpec{
@@ -241,5 +247,9 @@ func TestSetNonDefault(t *testing.T) {
 		Status: FlinkClusterStatus{},
 	}
 
-	assert.DeepEqual(t, cluster, expectedCluster)
+	assert.DeepEqual(
+		t,
+		cluster,
+		expectedCluster,
+		cmpopts.IgnoreUnexported(resource.Quantity{}))
 }

--- a/api/v1alpha1/flinkcluster_types.go
+++ b/api/v1alpha1/flinkcluster_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -154,8 +155,10 @@ type JobManagerSpec struct {
 	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 25
 	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
 
-	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600
-	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600M
+	// You can express this value like 600M, 572Mi and 600e6
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+	MemoryOffHeapMin resource.Quantity `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the JobManager pod.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
@@ -200,8 +203,10 @@ type TaskManagerSpec struct {
 	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 25
 	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
 
-	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600
-	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600M
+	// You can express this value like 600M, 572Mi and 600e6
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+	MemoryOffHeapMin resource.Quantity `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the TaskManager pods.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`

--- a/api/v1alpha1/flinkcluster_types.go
+++ b/api/v1alpha1/flinkcluster_types.go
@@ -151,10 +151,10 @@ type JobManagerSpec struct {
 
 	// TODO: Memory calculation would be change. Let's watch the issue FLINK-13980.
 
-	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 25
 	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
 
-	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600
 	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the JobManager pod.
@@ -197,10 +197,10 @@ type TaskManagerSpec struct {
 
 	// TODO: Memory calculation would be change. Let's watch the issue FLINK-13980.
 
-	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 25
 	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
 
-	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill, default: 600
 	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the TaskManager pods.

--- a/api/v1alpha1/flinkcluster_types.go
+++ b/api/v1alpha1/flinkcluster_types.go
@@ -149,6 +149,14 @@ type JobManagerSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// TODO: Memory calculation would be change. Let's watch the issue FLINK-13980.
+
+	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
+
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
+
 	// Volumes in the JobManager pod.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
@@ -186,6 +194,14 @@ type TaskManagerSpec struct {
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// TODO: Memory calculation would be change. Let's watch the issue FLINK-13980.
+
+	// Percentage of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	MemoryOffHeapRatio *int32 `json:"memoryOffHeapRatio,omitempty"`
+
+	// Minimum amount of off-heap memory in containers, as a safety margin to avoid OOM kill.
+	MemoryOffHeapMin *int32 `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the TaskManager pods.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`

--- a/api/v1alpha1/flinkcluster_validate_test.go
+++ b/api/v1alpha1/flinkcluster_validate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 
 	"gotest.tools/assert"
@@ -33,8 +34,8 @@ func TestValidateCreate(t *testing.T) {
 	var dataPort int32 = 8005
 	var parallelism int32 = 2
 	var restartPolicy = corev1.RestartPolicyOnFailure
-	var memoryOffHeapRatio = int32(25)
-	var memoryOffHeapMin = int32(600)
+	var memoryOffHeapRatio int32 = 25
+	var memoryOffHeapMin = resource.MustParse("600M")
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
@@ -55,7 +56,7 @@ func TestValidateCreate(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -65,7 +66,7 @@ func TestValidateCreate(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -208,8 +209,8 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 	var queryPort int32 = 8003
 	var uiPort int32 = 8004
 	var dataPort int32 = 8005
-	var memoryOffHeapRatio = int32(25)
-	var memoryOffHeapMin = int32(600)
+	var memoryOffHeapRatio int32 = 25
+	var memoryOffHeapMin = resource.MustParse("600M")
 
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -231,7 +232,7 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -241,7 +242,7 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 		},
 	}
@@ -269,7 +270,7 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 1,
@@ -279,7 +280,7 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Query: nil,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 		},
 	}
@@ -307,7 +308,7 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 1,
@@ -316,12 +317,18 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("500M"),
+					},
+				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 		},
 	}
 	err = validator.ValidateCreate(&cluster)
-	expectedErr = "invalid taskmanager memory configuration, MemoryOffHeapMin is not specified"
+	expectedErr = "invalid taskmanager memory configuration, memory limit must be larger than MemoryOffHeapMin, memory limit: 500000000 bytes, memoryOffHeapMin: 600000000 bytes"
 	assert.Equal(t, err.Error(), expectedErr)
 }
 
@@ -336,8 +343,8 @@ func TestInvalidJobSpec(t *testing.T) {
 	var invalidRestartPolicy = corev1.RestartPolicy("XXX")
 	var validator = &Validator{}
 	var parallelism int32 = 2
-	var memoryOffHeapRatio = int32(25)
-	var memoryOffHeapMin = int32(600)
+	var memoryOffHeapRatio int32 = 25
+	var memoryOffHeapMin = resource.MustParse("600M")
 
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -359,7 +366,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -369,7 +376,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "",
@@ -401,7 +408,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -411,7 +418,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -443,7 +450,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -453,7 +460,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -486,7 +493,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					UI:    &uiPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -496,7 +503,7 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",

--- a/api/v1alpha1/flinkcluster_validate_test.go
+++ b/api/v1alpha1/flinkcluster_validate_test.go
@@ -33,6 +33,8 @@ func TestValidateCreate(t *testing.T) {
 	var dataPort int32 = 8005
 	var parallelism int32 = 2
 	var restartPolicy = corev1.RestartPolicyOnFailure
+	var memoryOffHeapRatio = int32(25)
+	var memoryOffHeapMin = int32(600)
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
@@ -52,6 +54,8 @@ func TestValidateCreate(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -60,6 +64,8 @@ func TestValidateCreate(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -202,6 +208,8 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 	var queryPort int32 = 8003
 	var uiPort int32 = 8004
 	var dataPort int32 = 8005
+	var memoryOffHeapRatio = int32(25)
+	var memoryOffHeapMin = int32(600)
 
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -222,6 +230,8 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -230,6 +240,8 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 		},
 	}
@@ -256,6 +268,8 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 1,
@@ -264,11 +278,50 @@ func TestInvalidTaskManagerSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: nil,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 		},
 	}
 	err = validator.ValidateCreate(&cluster)
 	expectedErr = "taskmanager query port is unspecified"
+	assert.Equal(t, err.Error(), expectedErr)
+
+	cluster = FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: "default",
+		},
+		Spec: FlinkClusterSpec{
+			Image: ImageSpec{
+				Name:       "flink:1.8.1",
+				PullPolicy: corev1.PullPolicy("Always"),
+			},
+			JobManager: JobManagerSpec{
+				Replicas:    &jmReplicas,
+				AccessScope: AccessScope.VPC,
+				Ports: JobManagerPorts{
+					RPC:   &rpcPort,
+					Blob:  &blobPort,
+					Query: &queryPort,
+					UI:    &uiPort,
+				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+			},
+			TaskManager: TaskManagerSpec{
+				Replicas: 1,
+				Ports: TaskManagerPorts{
+					RPC:   &rpcPort,
+					Data:  &dataPort,
+					Query: &queryPort,
+				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+			},
+		},
+	}
+	err = validator.ValidateCreate(&cluster)
+	expectedErr = "invalid taskmanager memory configuration, MemoryOffHeapMin is not specified"
 	assert.Equal(t, err.Error(), expectedErr)
 }
 
@@ -283,6 +336,8 @@ func TestInvalidJobSpec(t *testing.T) {
 	var invalidRestartPolicy = corev1.RestartPolicy("XXX")
 	var validator = &Validator{}
 	var parallelism int32 = 2
+	var memoryOffHeapRatio = int32(25)
+	var memoryOffHeapMin = int32(600)
 
 	var cluster = FlinkCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -303,6 +358,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -311,6 +368,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "",
@@ -341,6 +400,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -349,6 +410,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -379,6 +442,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -387,6 +452,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",
@@ -418,6 +485,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Query: &queryPort,
 					UI:    &uiPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 3,
@@ -426,6 +495,8 @@ func TestInvalidJobSpec(t *testing.T) {
 					Data:  &dataPort,
 					Query: &queryPort,
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			Job: &JobSpec{
 				JarFile:       "gs://my-bucket/myjob.jar",

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -328,11 +328,7 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.MemoryOffHeapMin != nil {
-		in, out := &in.MemoryOffHeapMin, &out.MemoryOffHeapMin
-		*out = new(int32)
-		**out = **in
-	}
+	out.MemoryOffHeapMin = in.MemoryOffHeapMin.DeepCopy()
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -505,11 +501,7 @@ func (in *TaskManagerSpec) DeepCopyInto(out *TaskManagerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.MemoryOffHeapMin != nil {
-		in, out := &in.MemoryOffHeapMin, &out.MemoryOffHeapMin
-		*out = new(int32)
-		**out = **in
-	}
+	out.MemoryOffHeapMin = in.MemoryOffHeapMin.DeepCopy()
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -323,6 +323,16 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 	}
 	in.Ports.DeepCopyInto(&out.Ports)
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.MemoryOffHeapRatio != nil {
+		in, out := &in.MemoryOffHeapRatio, &out.MemoryOffHeapRatio
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MemoryOffHeapMin != nil {
+		in, out := &in.MemoryOffHeapMin, &out.MemoryOffHeapMin
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -490,6 +500,16 @@ func (in *TaskManagerSpec) DeepCopyInto(out *TaskManagerSpec) {
 	*out = *in
 	in.Ports.DeepCopyInto(&out.Ports)
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.MemoryOffHeapRatio != nil {
+		in, out := &in.MemoryOffHeapRatio, &out.MemoryOffHeapRatio
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MemoryOffHeapMin != nil {
+		in, out := &in.MemoryOffHeapMin, &out.MemoryOffHeapMin
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1840,9 +1840,9 @@ spec:
                   type: object
                 memoryOffHeapMin:
                   description: 'Minimum amount of off-heap memory in containers, as
-                    a safety margin to avoid OOM kill, default: 600'
-                  format: int32
-                  type: integer
+                    a safety margin to avoid OOM kill, default: 600M You can express
+                    this value like 600M, 572Mi and 600e6 More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory'
+                  type: string
                 memoryOffHeapRatio:
                   description: 'Percentage of off-heap memory in containers, as a
                     safety margin to avoid OOM kill, default: 25'
@@ -3144,9 +3144,9 @@ spec:
               properties:
                 memoryOffHeapMin:
                   description: 'Minimum amount of off-heap memory in containers, as
-                    a safety margin to avoid OOM kill, default: 600'
-                  format: int32
-                  type: integer
+                    a safety margin to avoid OOM kill, default: 600M You can express
+                    this value like 600M, 572Mi and 600e6 More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory'
+                  type: string
                 memoryOffHeapRatio:
                   description: 'Percentage of off-heap memory in containers, as a
                     safety margin to avoid OOM kill, default: 25'

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1839,13 +1839,13 @@ spec:
                       type: boolean
                   type: object
                 memoryOffHeapMin:
-                  description: Minimum amount of off-heap memory in containers, as
-                    a safety margin to avoid OOM kill.
+                  description: 'Minimum amount of off-heap memory in containers, as
+                    a safety margin to avoid OOM kill, default: 600'
                   format: int32
                   type: integer
                 memoryOffHeapRatio:
-                  description: Percentage of off-heap memory in containers, as a safety
-                    margin to avoid OOM kill.
+                  description: 'Percentage of off-heap memory in containers, as a
+                    safety margin to avoid OOM kill, default: 25'
                   format: int32
                   type: integer
                 mounts:
@@ -3143,13 +3143,13 @@ spec:
               description: Flink TaskManager spec.
               properties:
                 memoryOffHeapMin:
-                  description: Minimum amount of off-heap memory in containers, as
-                    a safety margin to avoid OOM kill.
+                  description: 'Minimum amount of off-heap memory in containers, as
+                    a safety margin to avoid OOM kill, default: 600'
                   format: int32
                   type: integer
                 memoryOffHeapRatio:
-                  description: Percentage of off-heap memory in containers, as a safety
-                    margin to avoid OOM kill.
+                  description: 'Percentage of off-heap memory in containers, as a
+                    safety margin to avoid OOM kill, default: 25'
                   format: int32
                   type: integer
                 mounts:

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1838,6 +1838,16 @@ spec:
                       description: TLS use.
                       type: boolean
                   type: object
+                memoryOffHeapMin:
+                  description: Minimum amount of off-heap memory in containers, as
+                    a safety margin to avoid OOM kill.
+                  format: int32
+                  type: integer
+                memoryOffHeapRatio:
+                  description: Percentage of off-heap memory in containers, as a safety
+                    margin to avoid OOM kill.
+                  format: int32
+                  type: integer
                 mounts:
                   description: Volume mounts in the JobManager container.
                   items:
@@ -3132,6 +3142,16 @@ spec:
             taskManager:
               description: Flink TaskManager spec.
               properties:
+                memoryOffHeapMin:
+                  description: Minimum amount of off-heap memory in containers, as
+                    a safety margin to avoid OOM kill.
+                  format: int32
+                  type: integer
+                memoryOffHeapRatio:
+                  description: Percentage of off-heap memory in containers, as a safety
+                    margin to avoid OOM kill.
+                  format: int32
+                  type: integer
                 mounts:
                   description: Volume mounts in the TaskManager containers.
                   items:

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -49,6 +49,8 @@ func TestGetDesiredClusterState(t *testing.T) {
 	var restartPolicy = corev1.RestartPolicy("OnFailure")
 	var className = "org.apache.flink.examples.java.wordcount.WordCount"
 	var hostFormat = "{{$clusterName}}.example.com"
+	var memoryOffHeapRatio int32 = 25
+	var memoryOffHeapMin int32 = 600
 
 	// Setup.
 	var cluster = &v1alpha1.FlinkCluster{
@@ -88,14 +90,16 @@ func TestGetDesiredClusterState(t *testing.T) {
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
-						"CPU":    resource.MustParse("100m"),
-						"Memory": resource.MustParse("256Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					},
 					Limits: map[corev1.ResourceName]resource.Quantity{
-						"CPU":    resource.MustParse("200m"),
-						"Memory": resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
 			},
 			TaskManager: v1alpha1.TaskManagerSpec{
 				Replicas: 42,
@@ -106,15 +110,17 @@ func TestGetDesiredClusterState(t *testing.T) {
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
-						"CPU":    resource.MustParse("200m"),
-						"Memory": resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 					Limits: map[corev1.ResourceName]resource.Quantity{
-						"CPU":    resource.MustParse("500m"),
-						"Memory": resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
-				Sidecars: []corev1.Container{{Name: "sidecar", Image: "alpine"}},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+				Sidecars:           []corev1.Container{{Name: "sidecar", Image: "alpine"}},
 				Volumes: []corev1.Volume{
 					{
 						Name: "cache-volume",
@@ -213,12 +219,12 @@ func TestGetDesiredClusterState(t *testing.T) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
-									"CPU":    resource.MustParse("100m"),
-									"Memory": resource.MustParse("256Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 								Limits: map[corev1.ResourceName]resource.Quantity{
-									"CPU":    resource.MustParse("200m"),
-									"Memory": resource.MustParse("512Mi"),
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{{
@@ -420,12 +426,12 @@ func TestGetDesiredClusterState(t *testing.T) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
-									"CPU":    resource.MustParse("200m"),
-									"Memory": resource.MustParse("512Mi"),
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 								Limits: map[corev1.ResourceName]resource.Quantity{
-									"CPU":    resource.MustParse("500m"),
-									"Memory": resource.MustParse("1Gi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
 							VolumeMounts: []v1.VolumeMount{
@@ -525,6 +531,7 @@ jobmanager.rpc.address: flinkjobcluster-sample-jobmanager
 jobmanager.rpc.port: 6123
 query.server.port: 6125
 rest.port: 8081
+taskmanager.heap.size: 424m
 taskmanager.numberOfTaskSlots: 1
 `
 	var expectedConfigMap = corev1.ConfigMap{
@@ -555,4 +562,74 @@ taskmanager.numberOfTaskSlots: 1
 		t,
 		*desiredState.ConfigMap,
 		expectedConfigMap)
+}
+
+func TestCalFlinkHeapSize(t *testing.T) {
+	var memoryOffHeapRatio = int32(25)
+	var memoryOffHeapMin = int32(600)
+
+	// Case 1: Heap sizes are computed from memoryOffHeapMin or memoryOffHeapRatio
+	cluster := &v1alpha1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.FlinkClusterSpec{
+			JobManager: v1alpha1.JobManagerSpec{
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+			},
+			TaskManager: v1alpha1.TaskManagerSpec{
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+			},
+		},
+	}
+
+	flinkHeapSize := calFlinkHeapSize(cluster)
+	expectedFlinkHeapSize := map[string]string{
+		"jobmanager.heap.size":  "424m",  // get values calculated with limit - memoryOffHeapMin
+		"taskmanager.heap.size": "3072m", // get values calculated with limit - limit * memoryOffHeapRatio / 100
+	}
+	assert.Assert(t, len(flinkHeapSize) == 2)
+	assert.DeepEqual(
+		t,
+		flinkHeapSize,
+		expectedFlinkHeapSize)
+
+	// Case 2: No values when memory limits are missing or insufficient
+	cluster = &v1alpha1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.FlinkClusterSpec{
+			JobManager: v1alpha1.JobManagerSpec{
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+				},
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+			},
+			TaskManager: v1alpha1.TaskManagerSpec{
+				MemoryOffHeapRatio: &memoryOffHeapRatio,
+				MemoryOffHeapMin:   &memoryOffHeapMin,
+			},
+		},
+	}
+
+	flinkHeapSize = calFlinkHeapSize(cluster)
+	assert.Assert(t, len(flinkHeapSize) == 0)
 }

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -50,7 +50,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 	var className = "org.apache.flink.examples.java.wordcount.WordCount"
 	var hostFormat = "{{$clusterName}}.example.com"
 	var memoryOffHeapRatio int32 = 25
-	var memoryOffHeapMin int32 = 600
+	var memoryOffHeapMin = resource.MustParse("600M")
 
 	// Setup.
 	var cluster = &v1alpha1.FlinkCluster{
@@ -99,7 +99,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 					},
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: v1alpha1.TaskManagerSpec{
 				Replicas: 42,
@@ -119,7 +119,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 					},
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 				Sidecars:           []corev1.Container{{Name: "sidecar", Image: "alpine"}},
 				Volumes: []corev1.Volume{
 					{
@@ -531,7 +531,7 @@ jobmanager.rpc.address: flinkjobcluster-sample-jobmanager
 jobmanager.rpc.port: 6123
 query.server.port: 6125
 rest.port: 8081
-taskmanager.heap.size: 424m
+taskmanager.heap.size: 474m
 taskmanager.numberOfTaskSlots: 1
 `
 	var expectedConfigMap = corev1.ConfigMap{
@@ -565,8 +565,8 @@ taskmanager.numberOfTaskSlots: 1
 }
 
 func TestCalFlinkHeapSize(t *testing.T) {
-	var memoryOffHeapRatio = int32(25)
-	var memoryOffHeapMin = int32(600)
+	var memoryOffHeapRatio int32 = 25
+	var memoryOffHeapMin = resource.MustParse("600M")
 
 	// Case 1: Heap sizes are computed from memoryOffHeapMin or memoryOffHeapRatio
 	cluster := &v1alpha1.FlinkCluster{
@@ -582,7 +582,7 @@ func TestCalFlinkHeapSize(t *testing.T) {
 					},
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: v1alpha1.TaskManagerSpec{
 				Resources: corev1.ResourceRequirements{
@@ -591,15 +591,15 @@ func TestCalFlinkHeapSize(t *testing.T) {
 					},
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 		},
 	}
 
 	flinkHeapSize := calFlinkHeapSize(cluster)
 	expectedFlinkHeapSize := map[string]string{
-		"jobmanager.heap.size":  "424m",  // get values calculated with limit - memoryOffHeapMin
-		"taskmanager.heap.size": "3072m", // get values calculated with limit - limit * memoryOffHeapRatio / 100
+		"jobmanager.heap.size":  "474m",  // get values calculated with limit - memoryOffHeapMin
+		"taskmanager.heap.size": "3222m", // get values calculated with limit - limit * memoryOffHeapRatio / 100
 	}
 	assert.Assert(t, len(flinkHeapSize) == 2)
 	assert.DeepEqual(
@@ -621,11 +621,11 @@ func TestCalFlinkHeapSize(t *testing.T) {
 					},
 				},
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 			TaskManager: v1alpha1.TaskManagerSpec{
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
-				MemoryOffHeapMin:   &memoryOffHeapMin,
+				MemoryOffHeapMin:   memoryOffHeapMin,
 			},
 		},
 	}

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -28,6 +28,8 @@ FlinkCluster
             |__ UseTLS
             |__ TLSSecretName
         |__ Resources
+        |__ MemoryOffHeapRatio
+        |__ MemoryOffHeapMin
         |__ Volumes
         |__ Mounts
     |__ TaskManagerSpec
@@ -37,6 +39,8 @@ FlinkCluster
             |__ RPD
             |__ Query
         |__ Resources
+        |__ MemoryOffHeapRatio
+        |__ MemoryOffHeapMin
         |__ Volumes
         |__ Mounts
     |__ JobSpec
@@ -100,6 +104,13 @@ FlinkCluster
       * **Resources** (optional): Compute resources required by JobManager
         container. If omitted, a default value will be used.
         More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      * **MemoryOffHeapRatio** (optional): Percentage of off-heap memory in containers,
+        as a safety margin, default: 25
+      * **MemoryOffHeapMin** (optional): Minimum amount of off-heap memory in containers,
+        as a safety margin, default: 600M.
+        You can express this value like 600M, 572Mi and 600e6.
+        More info about value expression:
+        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
       * **Volumes** (optional): Volumes in the JobManager pod.
         More info: https://kubernetes.io/docs/concepts/storage/volumes/
       * **Mounts** (optional): Volume mounts in the JobManager container.
@@ -113,6 +124,13 @@ FlinkCluster
       * **Resources** (optional): Compute resources required by JobManager
         container. If omitted, a default value will be used.
         More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      * **MemoryOffHeapRatio** (optional): Percentage of off-heap memory in containers,
+        as a safety margin, default: 25
+      * **MemoryOffHeapMin** (optional): Minimum amount of off-heap memory in containers,
+        as a safety margin, default: 600M.
+        You can express this value like 600M, 572Mi and 600e6.
+        More info about value expression:
+        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
       * **Volumes** (optional): Volumes in the TaskManager pod.
         More info: https://kubernetes.io/docs/concepts/storage/volumes/
       * **Mounts** (optional): Volume mounts in the TaskManager containers.


### PR DESCRIPTION
In order to run the Flink processes stably and avoid OOM kill in a container environment, appropriate off-heap space is required. Since jobmanager.heap.size and taskmanager.heap.size are the properties that determines the size of the Flink JVM heap, it is needed to calculate them based on the memory resource limit of the pod like Flink resource manager does for yarn cluster.
(https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html#resource-manager)

And since the files mounted with ConfigMap are read-only, it is not possible to modify the flink-conf.yaml in the entrypoint script with environment variables inside the container.

Memory related configurations would be changed in future release.

* Note: related issues
  - https://jira.apache.org/jira/browse/FLINK-13980
  - https://cwiki.apache.org/confluence/display/FLINK/FLIP-49%3A+Unified+Memory+Configuration+for+TaskExecutors
  - https://issues.apache.org/jira/browse/FLINK-13445