### PR TITLE
Support initContainers in JobSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ The operator is still under active development, there is not Helm chart availabl
 
 * [Developer Guide](docs/developer-guide.md)
 * [FlinkCluster Custom Resource Definition](docs/crd.md)
-* [Integrate Flink with GCS](images/flink/README.MD)
 * [Test environment setup for streaming applications](docs/streaming_test_env_setup.md)
+* [Use remote job JAR in GCS](config/samples/flinkoperator_v1alpha1_remotejobjar.yaml)
+* [Use GCS as remote storage with custom Flink images](images/flink/README.MD)
 
 ## Contributing
 

--- a/api/v1alpha1/flinkcluster_types.go
+++ b/api/v1alpha1/flinkcluster_types.go
@@ -209,9 +209,11 @@ type TaskManagerSpec struct {
 	MemoryOffHeapMin resource.Quantity `json:"memoryOffHeapMin,omitempty"`
 
 	// Volumes in the TaskManager pods.
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes/
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// Volume mounts in the TaskManager containers.
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes/
 	Mounts []corev1.VolumeMount `json:"mounts,omitempty"`
 
 	// Selector which must match a node's labels for the TaskManager pod to be
@@ -276,10 +278,18 @@ type JobSpec struct {
 	NoLoggingToStdout *bool `json:"noLoggingToStdout,omitempty"`
 
 	// Volumes in the Job pod.
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes/
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// Volume mounts in the Job container.
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes/
 	Mounts []corev1.VolumeMount `json:"mounts,omitempty"`
+
+	// Init containers of the Job pod. A typical use case could be using an init
+	// container to download a remote job jar to a local path which is
+	// referenced by the `jarFile` property.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// Restart policy, "OnFailure" or "Never", default: "OnFailure".
 	RestartPolicy *corev1.RestartPolicy `json:"restartPolicy"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -419,6 +419,13 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.InitContainers != nil {
+		in, out := &in.InitContainers, &out.InitContainers
+		*out = make([]v1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.RestartPolicy != nil {
 		in, out := &in.RestartPolicy, &out.RestartPolicy
 		*out = new(v1.RestartPolicy)

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -553,11 +553,885 @@ spec:
                       description: Action to take after job succeeds.
                       type: string
                   type: object
+                initContainers:
+                  description: 'Init containers of the Job pod. A typical use case
+                    could be using an init container to download a remote job jar
+                    to a local path which is referenced by the `jarFile` property.
+                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  items:
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The docker image''s
+                          CMD is used if this is not provided. Variable references
+                          $(VAR_NAME) are expanded using the container''s environment.
+                          If a variable cannot be resolved, the reference in the input
+                          string will be unchanged. The $(VAR_NAME) syntax can be
+                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                          The docker image''s ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container''s
+                          environment. If a variable cannot be resolved, the reference
+                          in the input string will be unchanged. The $(VAR_NAME) syntax
+                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                          references will never be expanded, regardless of whether
+                          the variable exists or not. Cannot be updated. More info:
+                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        it's key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, metadata.labels,
+                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                    status.hostIP, status.podIP.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or it's
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must
+                          be a C_IDENTIFIER. All invalid keys will be reported as
+                          an event when the container is starting. When a key exists
+                          in multiple sources, the value associated with the last
+                          source will take precedence. Values defined by an Env with
+                          a duplicate key will take precedence. Cannot be updated.
+                        items:
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      image:
+                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management
+                          to default or override container images in workload controllers
+                          like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent
+                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a
+                              container is created. If the handler fails, the container
+                              is terminated and restarted according to its restart
+                              policy. Other management of the container blocks until
+                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                              is terminated due to an API request or management event
+                              such as liveness probe failure, preemption, resource
+                              contention, etc. The handler is not called if the container
+                              crashes or exits. The reason for termination is passed
+                              to the handler. The Pod''s termination grace period
+                              countdown begins before the PreStop hooked is executed.
+                              Regardless of the outcome of the handler, the container
+                              will eventually terminate within the Pod''s termination
+                              grace period. Other management of the container blocks
+                              until the hook completes or until the termination grace
+                              period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                          will be restarted if the probe fails. Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                            required:
+                            - port
+                            type: object
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Exposing
+                          a port here gives the system additional information about
+                          the network connections a container uses, but is primarily
+                          informational. Not specifying a port here DOES NOT prevent
+                          that port from being exposed. Any port which is listening
+                          on the default "0.0.0.0" address inside a container will
+                          be accessible from the network. Cannot be updated.
+                        items:
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x <
+                                65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x
+                                < 65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              description: Protocol for port. Must be UDP, TCP, or
+                                SCTP. Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the
+                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                            required:
+                            - port
+                            type: object
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resources:
+                        description: 'Compute Resources required by this container.
+                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              type: string
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              type: string
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Security options the pod should run with. More
+                          info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set,
+                          reads from stdin in the container will always result in
+                          EOF. Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If
+                          this flag is false, a container processes that reads from
+                          stdin will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                          container''s termination message will be written is mounted
+                          into the container''s filesystem. Message written is intended
+                          to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes.
+                          The total message length across all containers will be limited
+                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: Indicate how the termination message should be
+                          populated. File will use the contents of terminationMessagePath
+                          to populate the container status message on both success
+                          and failure. FallbackToLogsOnError will use the last chunk
+                          of container log output if the termination message file
+                          is empty and the container exited with an error. The log
+                          output is limited to 2048 bytes or 80 lines, whichever is
+                          smaller. Defaults to File. Cannot be updated.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY
+                          for itself, also requires 'stdin' to be true. Default is
+                          false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to
+                          be used by the container. This is a beta feature.
+                        items:
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                          - name
+                          - devicePath
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive. This field is alpha in 1.14.
+                              type: string
+                          required:
+                          - name
+                          - mountPath
+                          type: object
+                        type: array
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
                 jarFile:
                   description: JAR file of the job.
                   type: string
                 mounts:
-                  description: Volume mounts in the Job container.
+                  description: 'Volume mounts in the Job container. More info: https://kubernetes.io/docs/concepts/storage/volumes/'
                   items:
                     properties:
                       mountPath:
@@ -611,7 +1485,7 @@ spec:
                   description: Savepoints dir where to store automatically taken savepoints.
                   type: string
                 volumes:
-                  description: Volumes in the Job pod.
+                  description: 'Volumes in the Job pod. More info: https://kubernetes.io/docs/concepts/storage/volumes/'
                   items:
                     properties:
                       awsElasticBlockStore:
@@ -3153,7 +4027,8 @@ spec:
                   format: int32
                   type: integer
                 mounts:
-                  description: Volume mounts in the TaskManager containers.
+                  description: 'Volume mounts in the TaskManager containers. More
+                    info: https://kubernetes.io/docs/concepts/storage/volumes/'
                   items:
                     properties:
                       mountPath:
@@ -4109,7 +4984,7 @@ spec:
                     type: object
                   type: array
                 volumes:
-                  description: Volumes in the TaskManager pods.
+                  description: 'Volumes in the TaskManager pods. More info: https://kubernetes.io/docs/concepts/storage/volumes/'
                   items:
                     properties:
                       awsElasticBlockStore:

--- a/config/samples/flinkoperator_v1alpha1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1alpha1_flinkjobcluster.yaml
@@ -18,13 +18,13 @@ metadata:
   name: flinkjobcluster-sample
 spec:
   image:
-    name: flink:1.8.1
+    name: flink:1.8.2
   jobManager:
     ports:
       ui: 8081
     resources:
       limits:
-        memory: "512Mi"
+        memory: "1024Mi"
         cpu: "200m"
   taskManager:
     replicas: 2

--- a/config/samples/flinkoperator_v1alpha1_remotejobjar.yaml
+++ b/config/samples/flinkoperator_v1alpha1_remotejobjar.yaml
@@ -12,42 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Example demonstrating downloading remote job jar from GCS.
+# This allows you to reuse the Flink image without requiring you to build a
+# custom image with the job jar inside.
+
 apiVersion: flinkoperator.k8s.io/v1alpha1
 kind: FlinkCluster
 metadata:
-  name: flinksessioncluster-sample
+  name: flinkjobcluster-gcs
 spec:
   image:
     name: flink:1.8.2
-    pullPolicy: Always
   jobManager:
-    accessScope: Cluster
     ports:
       ui: 8081
     resources:
       limits:
         memory: "1024Mi"
-        cpu: "200m"
   taskManager:
-    replicas: 1
+    replicas: 2
     resources:
       limits:
         memory: "1024Mi"
-        cpu: "200m"
+  job:
+    jarFile: /cache/wordcount.jar
+    className: org.apache.flink.streaming.examples.wordcount.WordCount
+    args: ["--input", "./README.txt"]
+    parallelism: 2
     volumes:
       - name: cache-volume
         emptyDir: {}
     mounts:
       - mountPath: /cache
         name: cache-volume
-    sidecars:
-      - name: sidecar
-        image: alpine
-        command:
-          - "sleep"
-          - "10000"
-  envVars:
-    - name: FOO
-      value: bar
-  flinkProperties:
-    taskmanager.numberOfTaskSlots: "1"
+    initContainers:
+      - name: gcs-downloader
+        image: google/cloud-sdk
+        command: ["gsutil"]
+        args:
+          - "cp"
+          - "gs://my-bucket/wordcount.jar"
+          - "/cache/wordcount.jar"

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -43,18 +43,23 @@ FlinkCluster
         |__ MemoryOffHeapMin
         |__ Volumes
         |__ Mounts
+        |__ Sidecars
     |__ JobSpec
         |__ JarFile
         |__ ClassName
         |__ Args
         |__ Savepoint
         |__ AllowNonRestoredState
+        |__ AutoSavepointSeconds
+        |__ SavepointsDir
         |__ Parallelism
         |__ NoLoggingToStdout
-        |__ RestartPolicy
         |__ Volumes
         |__ Mounts
-        |__ Sidecars
+        |__ InitContainers
+        |__ RestartPolicy
+        |__ CleanupPolicy
+        |__ CancelRequested
     |__ FlinkProperties
     |__ EnvVars
 |__ Status
@@ -149,9 +154,12 @@ FlinkCluster
       * **AllowNonRestoredState** (optional):  Allow non-restored state, default: false.
       * **Parallelism** (optional): Parallelism of the job, default: 1.
       * **NoLoggingToStdout** (optional): No logging output to STDOUT, default: false.
+      * **InitContainers** (optional): Init containers of the Job pod.
+        More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
       * **Volumes** (optional): Volumes in the Job pod.
         More info: https://kubernetes.io/docs/concepts/storage/volumes/
-      * **Mounts** (optional): Volume mounts in the Job container.
+      * **Mounts** (optional): Volume mounts in the Job containers. If there is no confilcts, these mounts will be
+        automatically added to init containers; otherwise, the mounts defined in init containers will take precedence.
         More info: https://kubernetes.io/docs/concepts/storage/volumes/
       * **RestartPolicy** (optional): Restart policy, `OnFailure` or `Never`, default: `OnFailure`.
       * **CleanupPolicy** (optional): The action to take after job finishes.
@@ -159,6 +167,8 @@ FlinkCluster
           `enum("KeepCluster", "DeleteCluster", "DeleteTaskManager")`, default `"DeleteCluster"`.
         * **AfterJobFails** (required): The action to take after job fails,
           `enum("KeepCluster", "DeleteCluster", "DeleteTaskManager")`, default `"KeepCluster"`.
+      * **CancelRequested** (optional): Request the job to be cancelled. Only applies to running jobs. If
+        `savePointsDir` is provided, a savepoint will be taken before stopping the job.
     * **FlinkProperties** (optional): Flink properties which are appened to flink-conf.yaml of the Flink image.
     * **EnvVars** (optional): Environment variables shared by all JobManager, TaskManager and job containers.
   * **Status**: Flink job or session cluster status.


### PR DESCRIPTION
A typical use case could be use an init container to download a remote
jar to a local path which is referenced by the jarFile field.