### PR TITLE
Disable restarting failed jobs at K8S job level

### DIFF
--- a/api/v1alpha1/flinkcluster_default.go
+++ b/api/v1alpha1/flinkcluster_default.go
@@ -113,8 +113,8 @@ func _SetJobDefault(jobSpec *JobSpec) {
 		*jobSpec.NoLoggingToStdout = false
 	}
 	if jobSpec.RestartPolicy == nil {
-		jobSpec.RestartPolicy = new(corev1.RestartPolicy)
-		*jobSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+		jobSpec.RestartPolicy = new(JobRestartPolicy)
+		*jobSpec.RestartPolicy = JobRestartPolicyNever
 	}
 	if jobSpec.CleanupPolicy == nil {
 		jobSpec.CleanupPolicy = &CleanupPolicy{

--- a/api/v1alpha1/flinkcluster_default_test.go
+++ b/api/v1alpha1/flinkcluster_default_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"testing"
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ func TestSetDefault(t *testing.T) {
 	var defaultJobAllowNonRestoredState = false
 	var defaultJobParallelism = int32(1)
 	var defaultJobNoLoggingToStdout = false
-	var defaultJobRestartPolicy = corev1.RestartPolicy("OnFailure")
+	var defaultJobRestartPolicy = JobRestartPolicyNever
 	var defatulJobManagerIngressTLSUse = false
 	var defaultMemoryOffHeapRatio = int32(25)
 	var defaultMemoryOffHeapMin = resource.MustParse("600M")
@@ -129,7 +130,7 @@ func TestSetNonDefault(t *testing.T) {
 	var jobAllowNonRestoredState = true
 	var jobParallelism = int32(2)
 	var jobNoLoggingToStdout = true
-	var jobRestartPolicy = corev1.RestartPolicy("Never")
+	var jobRestartPolicy = JobRestartPolicyFromSavepointOnFailure
 	var jobManagerIngressTLSUse = true
 	var memoryOffHeapRatio = int32(50)
 	var memoryOffHeapMin = resource.MustParse("600M")

--- a/api/v1alpha1/flinkcluster_validate.go
+++ b/api/v1alpha1/flinkcluster_validate.go
@@ -253,8 +253,8 @@ func (v *Validator) validateJob(jobSpec *JobSpec) error {
 		return fmt.Errorf("job restartPolicy is unspecified")
 	}
 	switch *jobSpec.RestartPolicy {
-	case corev1.RestartPolicyNever:
-	case corev1.RestartPolicyOnFailure:
+	case JobRestartPolicyNever:
+	case JobRestartPolicyFromSavepointOnFailure:
 	default:
 		return fmt.Errorf("invalid job restartPolicy: %v", *jobSpec.RestartPolicy)
 	}

--- a/api/v1alpha1/flinkcluster_validate_test.go
+++ b/api/v1alpha1/flinkcluster_validate_test.go
@@ -34,7 +34,7 @@ func TestValidateCreate(t *testing.T) {
 	var uiPort int32 = 8004
 	var dataPort int32 = 8005
 	var parallelism int32 = 2
-	var restartPolicy = corev1.RestartPolicyOnFailure
+	var restartPolicy = JobRestartPolicyFromSavepointOnFailure
 	var memoryOffHeapRatio int32 = 25
 	var memoryOffHeapMin = resource.MustParse("600M")
 	var cluster = FlinkCluster{
@@ -347,8 +347,8 @@ func TestInvalidJobSpec(t *testing.T) {
 	var queryPort int32 = 8003
 	var uiPort int32 = 8004
 	var dataPort int32 = 8005
-	var restartPolicy = corev1.RestartPolicyOnFailure
-	var invalidRestartPolicy = corev1.RestartPolicy("XXX")
+	var restartPolicy = JobRestartPolicyFromSavepointOnFailure
+	var invalidRestartPolicy = "XXX"
 	var validator = &Validator{}
 	var parallelism int32 = 2
 	var memoryOffHeapRatio int32 = 25

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -468,7 +468,7 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 	}
 	if in.RestartPolicy != nil {
 		in, out := &in.RestartPolicy, &out.RestartPolicy
-		*out = new(v1.RestartPolicy)
+		*out = new(string)
 		**out = **in
 	}
 	if in.CleanupPolicy != nil {

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1495,7 +1495,13 @@ spec:
                   format: int32
                   type: integer
                 restartPolicy:
-                  description: 'Restart policy, "OnFailure" or "Never", default: "OnFailure".'
+                  description: "Restart policy when the job fails, \"FromSavepointOnFailure\"
+                    or \"Never\", default: \"Never\". \n \"FromSavepointOnFailure\"
+                    means if there is a savepoint recorded in the job status, the
+                    operator will try to restart the failed job from the savepoint;
+                    otherwise, the job will stay in failed state. \n \"Never\" means
+                    the operator will never try to restart a failed job, manual cleanup
+                    is required."
                   type: string
                 savepoint:
                   description: Savepoint where to restore the job from (e.g., gs://my-savepoint/1234).

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -46,11 +46,12 @@ func TestGetDesiredClusterState(t *testing.T) {
 	var tmRPCPort int32 = 6122
 	var tmQueryPort int32 = 6125
 	var replicas int32 = 42
-	var restartPolicy = corev1.RestartPolicy("OnFailure")
+	var restartPolicy = v1alpha1.JobRestartPolicyFromSavepointOnFailure
 	var className = "org.apache.flink.examples.java.wordcount.WordCount"
 	var hostFormat = "{{$clusterName}}.example.com"
 	var memoryOffHeapRatio int32 = 25
 	var memoryOffHeapMin = resource.MustParse("600M")
+	var jobBackoffLimit int32 = 0
 	var jmProbe = corev1.Probe{
 		Handler: corev1.Handler{
 			TCPSocket: &corev1.TCPSocketAction{
@@ -631,7 +632,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 							},
 						},
 					},
-					RestartPolicy: "OnFailure",
+					RestartPolicy: v1alpha1.JobRestartPolicyNever,
 					Volumes: []corev1.Volume{
 						{
 							Name: "cache-volume",
@@ -650,6 +651,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 					},
 				},
 			},
+			BackoffLimit: &jobBackoffLimit,
 		},
 	}
 

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -119,18 +119,19 @@ Last successful or failed savepoint operation timestamp.
         * **tlsSecretName** (optional): Kubernetes secret resource name for TLS.
       * **resources** (optional): Compute resources required by JobManager
         container. If omitted, a default value will be used.
-        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+        See [more info](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) about
+        resources.
       * **memoryOffHeapRatio** (optional): Percentage of off-heap memory in containers,
         as a safety margin, default: 25
       * **memoryOffHeapMin** (optional): Minimum amount of off-heap memory in containers,
         as a safety margin, default: 600M.
         You can express this value like 600M, 572Mi and 600e6.
-        More info about value expression:
-        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+        See [more info](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory)
+        about value expression.
       * **volumes** (optional): Volumes in the JobManager pod.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) about volumes.
       * **mounts** (optional): Volume mounts in the JobManager container.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) volume mounts.
     * **taskManager** (required): TaskManager spec.
       * **replicas** (required): The number of TaskManager replicas.
       * **ports** (optional): Ports that TaskManager listening on.
@@ -139,20 +140,21 @@ Last successful or failed savepoint operation timestamp.
         * **query** (optional): Query port.
       * **resources** (optional): Compute resources required by JobManager
         container. If omitted, a default value will be used.
-        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+        See [more info](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) about
+        resources.
       * **memoryOffHeapRatio** (optional): Percentage of off-heap memory in containers,
         as a safety margin, default: 25
       * **memoryOffHeapMin** (optional): Minimum amount of off-heap memory in containers,
         as a safety margin, default: 600M.
         You can express this value like 600M, 572Mi and 600e6.
-        More info about value expression:
-        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+        See [more info](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory)
+        about value expression.
       * **volumes** (optional): Volumes in the TaskManager pod.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) about volumes.
       * **mounts** (optional): Volume mounts in the TaskManager containers.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) about volume mounts.
       * **sidecars** (optional): Sidecar containers running alongside with the TaskManager container in the pod.
-        More info: https://kubernetes.io/docs/concepts/containers/
+        See [more info](https://kubernetes.io/docs/concepts/containers/) about containers.
     * **job** (optional): Job spec. If specified, the cluster is a Flink job cluster; otherwise, it is a Flink
       session cluster.
       * **jarFile** (required): JAR file of the job. It could be a local file or remote URI, depending on which
@@ -166,13 +168,16 @@ Last successful or failed savepoint operation timestamp.
       * **parallelism** (optional): Parallelism of the job, default: 1.
       * **noLoggingToStdout** (optional): No logging output to STDOUT, default: false.
       * **initContainers** (optional): Init containers of the Job pod.
-        More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+        See [more info](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) about init containers.
       * **volumes** (optional): Volumes in the Job pod.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) about volumes.
       * **mounts** (optional): Volume mounts in the Job containers. If there is no confilcts, these mounts will be
         automatically added to init containers; otherwise, the mounts defined in init containers will take precedence.
-        More info: https://kubernetes.io/docs/concepts/storage/volumes/
-      * **restartPolicy** (optional): Restart policy, `OnFailure` or `Never`, default: `OnFailure`.
+        See [more info](https://kubernetes.io/docs/concepts/storage/volumes/) about volume mounts.
+      * **restartPolicy** (optional): Restart policy when the job fails, `FromSavepointOnFailure` or `Never`,
+        default: `Never`. `FromSavepointOnFailure` means if there is a savepoint recorded in the job status, the
+        operator will try to restart the failed job from the savepoint; otherwise, the job will stay in failed state.
+        `Never` means the operator will never try to restart a failed job, manual cleanup is required.
       * **cleanupPolicy** (optional): The action to take after job finishes.
         * **afterJobSucceeds** (required): The action to take after job succeeds,
           `enum("KeepCluster", "DeleteCluster", "DeleteTaskManager")`, default `"DeleteCluster"`.


### PR DESCRIPTION
Due to the stateful nature of Flink jobs, job restart is better to be initiated by the operator based on restart policy.