### PR TITLE
Support multiple operator deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ IMG ?= gcr.io/flink-operator/flink-operator:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 # The Kubernetes namespace in which the operator will be deployed.
 FLINK_OPERATOR_NAMESPACE ?= flink-operator-system
+# Prefix for Kubernetes resource names. When deploying multiple operators, make sure that the names of cluster-scoped resources are not duplicated.
+RESOURCE_PREFIX ?= flink-operator-
+# The Kubernetes namespace to limit watching.
+WATCH_NAMESPACE ?=
 
 #################### Local build and test ####################
 
@@ -81,29 +85,51 @@ install: manifests
 
 # Deploy cert-manager which is required by webhooks of the operator.
 webhook-cert:
-	bash scripts/generate_cert.sh --service flink-operator-webhook-service --secret webhook-server-cert -n $(FLINK_OPERATOR_NAMESPACE)
+	bash scripts/generate_cert.sh --service $(RESOURCE_PREFIX)webhook-service --secret webhook-server-cert -n $(FLINK_OPERATOR_NAMESPACE)
 
 config/default/manager_image_patch.yaml:
 	cp config/default/manager_image_patch.template config/default/manager_image_patch.yaml
 
+build-overlay:
+	rm -rf config/deploy && cp -rf config/default config/deploy && cd config/deploy \
+			&& kustomize edit set nameprefix $(RESOURCE_PREFIX) \
+			&& kustomize edit set namespace $(FLINK_OPERATOR_NAMESPACE)
+ifneq ($(WATCH_NAMESPACE),)
+	cd config/deploy \
+			&& sed -E -i.bak  "s/(\-\-watch\-namespace\=)/\1$(WATCH_NAMESPACE)/" manager_auth_proxy_patch.yaml \
+			&& kustomize edit add patch webhook_namespace_selector_patch.yaml \
+			|| true
+endif
+	sed -E -i.bak "s/resources:/bases:/" config/deploy/kustomization.yaml
+	rm config/deploy/*.bak
+
+template: build-overlay
+	kubectl kustomize config/deploy \
+			| sed -e "s/$(RESOURCE_PREFIX)system/$(FLINK_OPERATOR_NAMESPACE)/g"
+
 # Deploy the operator in the configured Kubernetes cluster in ~/.kube/config
-deploy: install webhook-cert config/default/manager_image_patch.yaml
+deploy: install webhook-cert config/default/manager_image_patch.yaml build-overlay
 	$(eval CA_BUNDLE := $(shell kubectl get secrets/webhook-server-cert -n $(FLINK_OPERATOR_NAMESPACE) -o jsonpath="{.data.tls\.crt}"))
-	kubectl kustomize config/default \
-			| sed -e "s/flink-operator-system/$(FLINK_OPERATOR_NAMESPACE)/g" \
-			| sed -e "s/--watch-namespace=/--watch-namespace=$(WATCH_NAMESPACE)/" \
+	kubectl kustomize config/deploy \
+			| sed -e "s/$(RESOURCE_PREFIX)system/$(FLINK_OPERATOR_NAMESPACE)/g" \
 			| sed -e "s/Cg==/$(CA_BUNDLE)/g" \
 			| kubectl apply -f -
+ifneq ($(WATCH_NAMESPACE),)
+    # Set the label on target namespace to support webhook namespaceSelector.
+	kubectl label ns $(WATCH_NAMESPACE) flink-operator-namespace=$(FLINK_OPERATOR_NAMESPACE)
+endif
 
 undeploy-crd:
 	kubectl delete -f config/crd/bases
 
-undeploy-controller:
-	kubectl kustomize config/default \
-			| sed -e "s/flink-operator-system/$(FLINK_OPERATOR_NAMESPACE)/g" \
-			| sed -e "s/--watch-namespace=/--watch-namespace=$(WATCH_NAMESPACE)/" \
+undeploy-controller: build-overlay
+	kubectl kustomize config/deploy \
+			| sed -e "s/$(RESOURCE_PREFIX)system/$(FLINK_OPERATOR_NAMESPACE)/g" \
 			| kubectl delete -f - \
 			|| true
+ifneq ($(WATCH_NAMESPACE),)
+	kubectl label ns $(WATCH_NAMESPACE) flink-operator-namespace-
+endif
 
 undeploy: undeploy-controller undeploy-crd
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -48,3 +48,13 @@ patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 - manager_webhook_patch.yaml
 
+vars:
+  # Webhook namespaceSelector reference this with key "flink-operator-namespace"
+  - name: OPERATOR_NAMESPACE
+    objref:
+      name: system
+      kind: Namespace
+      apiVersion: v1
+
+configurations:
+  - kustomizeconfig.yaml

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+varReference:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/namespaceSelector/matchExpressions/values
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/namespaceSelector/matchExpressions/values

--- a/config/default/webhook_namespace_selector_patch.yaml
+++ b/config/default/webhook_namespace_selector_patch.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mflinkcluster.flinkoperator.k8s.io
+  # Change selector below for your namespaces.
+  namespaceSelector:
+    matchExpressions:
+      - key: flink-operator-namespace
+        operator: "In"
+        values:
+          - $(OPERATOR_NAMESPACE)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: vflinkcluster.flinkoperator.k8s.io
+  # Change selector below for your namespaces.
+  namespaceSelector:
+    matchExpressions:
+      - key: flink-operator-namespace
+        operator: "In"
+        values:
+          - $(OPERATOR_NAMESPACE)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -77,6 +77,23 @@ INFO    controller-runtime.certwatcher  Starting certificate watcher
 INFO    controller-runtime.controller   Starting workers        {"controller": "flinkcluster", "worker count": 1}
 ```
 
+## Deploy multiple operators handle limited namespace.
+
+The Flink operator basically detects and processes all FlinkCluster resources
+created in one kubernetes cluster. However, depending on the usage environment,
+such as a multi-tenant cluster, the namespace to be managed by the operator
+may need to be limited. In this case, dedicated operators must be deployed
+for each namespace, and multiple operators may be deployed in one cluster.
+
+Deploy by specifying the namespace to manage and prefix to avoid duplication
+of cluster-scoped resources:
+
+```bash
+make deploy RESOURCE_PREFIX=<kuberntes-resource-name-prefix> \
+            WATCH_NAMESPACE=<namespace-to-watch> \
+            FLINK_OPERATOR_NAMESPACE=<namespace-to-deploy-operator>
+```
+
 ## Create a sample Flink cluster
 
 After deploying the Flink CRDs and the Flink Operator to a Kubernetes cluster,


### PR DESCRIPTION
Currently, Makefile supports only one operator deployment on one k8s cluster. It seems that the following template generation feature is required to deploy multiple operators.

- Avoid duplicate cluster-scoped resource names
- Support selector to prevent admission webhook call interference (namespaceSelector is used in this PR)

To do this, in this PR build-overlay action is added to the Makefile and webhook patch is added to kustomize config.

Operators can be deployed like:
```bash
make deploy  WATCH_NAMESPACE=dev RESOURCE_PREFIX=dev-
```