### PR TITLE
Exit with non-zero code when job failed or was canceled

### DIFF
--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -66,9 +66,17 @@ function wait_for_job() {
 	while true; do
 		echo -e "\nWaiting for job to finish..."
 		list_jobs
-		if list_jobs | grep -e "(FINISHED)" -e "(FAILED)" -e "(CANCELED)"; then
-			echo -e "\nJob has terminated, exiting..."
-			break
+		if list_jobs | grep "(FINISHED)"; then
+			echo -e "\nJob has completed successfully, exiting 0"
+			return 0
+		fi
+		if list_jobs | grep "(FAILED)"; then
+			echo -e "\nJob failed, exiting 1"
+			return 1
+		fi
+		if list_jobs | grep "(CANCELED)"; then
+			echo -e "\nJob has been cancelled, exiting 2"
+			return 2
 		fi
 		sleep 30
 	done


### PR DESCRIPTION
Fix #218