### PR TITLE
Using Semantic Versioning for Chart version.

### DIFF
--- a/helm-chart/flink-operator/Chart.yaml
+++ b/helm-chart/flink-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: flink-operator
 appVersion: "1.0"
 description: A Helm chart for flink on Kubernetes operator
-version: v1beta1
+version: "0.1.0"
 keywords:
   - flink
 home: https://github.com/GoogleCloudPlatform/flink-on-k8s-operator


### PR DESCRIPTION
I got an exception when trying to push this charts to the my server.
It show me that the chart version shoud use the Semantic Versioning. If the version is not "Semantic Versioning"， the chart server will not recognize it.
Semantic version Guide: https://semver.org/