### PR TITLE
Check active job first to decide job state

### DIFF
--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -72,7 +72,6 @@ function wait_for_job() {
 		# TODO: It needs to be improved to determine the job state with the submitted job id.
 		if list_jobs | grep -e "(SCHEDULED)" -e "(RUNNING)"; then
 			echo -e "\nFound an active job."
-			sleep 30
 		else
 			if list_jobs | grep "(FINISHED)"; then
 				echo -e "\nJob has completed successfully, exiting 0"
@@ -89,6 +88,7 @@ function wait_for_job() {
 			echo -e "\nUnknown job state, exiting 3"
 			return 3
 		fi
+		sleep 30
 	done
 }
 

--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -66,6 +66,10 @@ function wait_for_job() {
 	while true; do
 		echo -e "\nWaiting for job to finish..."
 		list_jobs
+
+		# Find active job first.
+		# If the current job is restarted by the operator, there will be records of past stopped jobs.
+		# TODO: It needs to be improved to determine the job state with the submitted job id.
 		if list_jobs | grep -e "(SCHEDULED)" -e "(RUNNING)"; then
 			echo -e "\nFound an active job."
 			sleep 30
@@ -82,6 +86,8 @@ function wait_for_job() {
 				echo -e "\nJob has been cancelled, exiting 2"
 				return 2
 			fi
+			echo -e "\nUnknown job state, exiting 3"
+			return 3
 		fi
 	done
 }

--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -66,19 +66,23 @@ function wait_for_job() {
 	while true; do
 		echo -e "\nWaiting for job to finish..."
 		list_jobs
-		if list_jobs | grep "(FINISHED)"; then
-			echo -e "\nJob has completed successfully, exiting 0"
-			return 0
+		if list_jobs | grep -e "(SCHEDULED)" -e "(RUNNING)"; then
+			echo -e "\nFound an active job."
+			sleep 30
+		else
+			if list_jobs | grep "(FINISHED)"; then
+				echo -e "\nJob has completed successfully, exiting 0"
+				return 0
+			fi
+			if list_jobs | grep "(FAILED)"; then
+				echo -e "\nJob failed, exiting 1"
+				return 1
+			fi
+			if list_jobs | grep "(CANCELED)"; then
+				echo -e "\nJob has been cancelled, exiting 2"
+				return 2
+			fi
 		fi
-		if list_jobs | grep "(FAILED)"; then
-			echo -e "\nJob failed, exiting 1"
-			return 1
-		fi
-		if list_jobs | grep "(CANCELED)"; then
-			echo -e "\nJob has been cancelled, exiting 2"
-			return 2
-		fi
-		sleep 30
 	done
 }
 


### PR DESCRIPTION
It seems we need to check active jobs first to decide job state.
It would be better if we improved it later to determine the state with the submitted job ID. 

#231 