### PR TITLE
Cancel job with non-blocking savepoint

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -75,8 +75,8 @@ const (
 	ControlAnnotation = "flinkclusters.flinkoperator.k8s.io/user-control"
 
 	// control name
-	ControlNameCancel    = "job-cancel"
 	ControlNameSavepoint = "savepoint"
+	ControlNameJobCancel = "job-cancel"
 
 	// control state
 	ControlStateProgressing = "Progressing"

--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -87,7 +87,7 @@ const (
 // Savepoint status
 const (
 	SavepointStateNotTriggered  = "NotTriggered"
-	SavepointStateProgressing   = "Progressing"
+	SavepointStateInProgress    = "InProgress"
 	SavepointStateTriggerFailed = "TriggerFailed"
 	SavepointStateFailed        = "Failed"
 	SavepointStateSucceeded     = "Succeeded"

--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -84,6 +84,19 @@ const (
 	ControlStateFailed      = "Failed"
 )
 
+// Savepoint status
+const (
+	SavepointStateNotTriggered  = "NotTriggered"
+	SavepointStateProgressing   = "Progressing"
+	SavepointStateTriggerFailed = "TriggerFailed"
+	SavepointStateFailed        = "Failed"
+	SavepointStateSucceeded     = "Succeeded"
+
+	SavepointTriggerReasonUserRequested = "user requested"
+	SavepointTriggerReasonJobCancel     = "for job-cancel"
+	SavepointTriggerReasonScheduled     = "scheduled"
+)
+
 // ImageSpec defines Flink image of JobManager and TaskManager containers.
 type ImageSpec struct {
 	// Flink image name.

--- a/api/v1beta1/flinkcluster_validate.go
+++ b/api/v1beta1/flinkcluster_validate.go
@@ -111,10 +111,10 @@ func (v *Validator) checkControlAnnotations(old *FlinkCluster, new *FlinkCluster
 			return fmt.Errorf(ControlChangeWarnMsg, ControlAnnotation)
 		}
 		switch newUserControl {
-		case ControlNameCancel:
+		case ControlNameJobCancel:
 			var jobStatus = old.Status.Components.Job
 			if old.Spec.Job == nil {
-				return fmt.Errorf(SessionClusterWarnMsg, ControlNameCancel, ControlAnnotation)
+				return fmt.Errorf(SessionClusterWarnMsg, ControlNameJobCancel, ControlAnnotation)
 			} else if jobStatus == nil || isJobTerminated(old.Spec.Job.RestartPolicy, jobStatus) {
 				return fmt.Errorf(InvalidJobStateForJobCancelMsg, ControlAnnotation)
 			}

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -590,7 +590,7 @@ func getDesiredJob(
 	// We need to watch whether job is cancelled already if jobSpec.CancelRequested is deprecated
 	if (flinkCluster.Status.Components.Job != nil && flinkCluster.Status.Components.Job.State == v1beta1.JobStateCancelled) ||
 		(jobSpec.CancelRequested != nil && *jobSpec.CancelRequested) ||
-		(controlStatus != nil && controlStatus.Name == v1beta1.ControlNameCancel && controlStatus.State == v1beta1.ControlStateProgressing) {
+		(controlStatus != nil && controlStatus.Name == v1beta1.ControlNameJobCancel && controlStatus.State == v1beta1.ControlStateProgressing) {
 		return nil
 	}
 

--- a/controllers/flinkcluster_observer.go
+++ b/controllers/flinkcluster_observer.go
@@ -278,7 +278,7 @@ func (observer *ClusterStateObserver) observeSavepoint(observed *ObservedCluster
 
 	// Get savepoint status in progress.
 	var savepointStatus = observed.cluster.Status.Savepoint
-	if isSavepointTriggered(savepointStatus) {
+	if savepointStatus != nil && savepointStatus.State == v1beta1.SavepointStateProgressing {
 		var flinkAPIBaseURL = getFlinkAPIBaseURL(observed.cluster)
 		var jobID = savepointStatus.JobID
 		var triggerID = savepointStatus.TriggerID

--- a/controllers/flinkcluster_observer.go
+++ b/controllers/flinkcluster_observer.go
@@ -278,7 +278,7 @@ func (observer *ClusterStateObserver) observeSavepoint(observed *ObservedCluster
 
 	// Get savepoint status in progress.
 	var savepointStatus = observed.cluster.Status.Savepoint
-	if savepointStatus != nil && savepointStatus.State == v1beta1.SavepointStateProgressing {
+	if savepointStatus != nil && savepointStatus.State == v1beta1.SavepointStateInProgress {
 		var flinkAPIBaseURL = getFlinkAPIBaseURL(observed.cluster)
 		var jobID = savepointStatus.JobID
 		var triggerID = savepointStatus.TriggerID

--- a/controllers/flinkcluster_observer.go
+++ b/controllers/flinkcluster_observer.go
@@ -277,9 +277,7 @@ func (observer *ClusterStateObserver) observeSavepoint(observed *ObservedCluster
 
 	// Get savepoint status in progress.
 	var savepointStatus = observed.cluster.Status.Savepoint
-	if savepointStatus != nil &&
-		savepointStatus.State == SavepointStateProgressing &&
-		savepointStatus.TriggerID != "" {
+	if isSavepointTriggered(savepointStatus) {
 		var flinkAPIBaseURL = getFlinkAPIBaseURL(observed.cluster)
 		var jobID = savepointStatus.JobID
 		var triggerID = savepointStatus.TriggerID

--- a/controllers/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster_reconciler.go
@@ -647,7 +647,7 @@ func (reconciler *ClusterReconciler) takeSavepointAsync(jobID string, triggerRea
 	if err != nil {
 		// limit message size to 1KiB
 		if message = err.Error(); len(message) > 1024 {
-			message = message[:1024]
+			message = message[:1024] + "..."
 		}
 		triggerSuccess = false
 		log.Info("Savepoint trigger is failed.", "jobID", jobID, "triggerID", triggerID, "error", err)
@@ -733,7 +733,7 @@ func getFailedCancelStatus(cancelErr error) *v1beta1.FlinkClusterControlStatus {
 	state = v1beta1.ControlStateProgressing
 	// limit message size to 1KiB
 	if message = cancelErr.Error(); len(message) > 1024 {
-		message = message[:1024]
+		message = message[:1024] + "..."
 	}
 	return &v1beta1.FlinkClusterControlStatus{
 		Name:       v1beta1.ControlNameJobCancel,

--- a/controllers/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster_reconciler.go
@@ -567,6 +567,13 @@ func (reconciler *ClusterReconciler) cancelFlinkJobAsync(jobID string, takeSavep
 			}
 			savepointStatus = nil
 			log.Info("Savepoint was desired but couldn't be taken. Skip taking savepoint before stopping job", "jobID", jobID)
+		// Cannot reach here with these states, because job-cancel control should be finished with failed states by updater.
+		case v1beta1.SavepointStateTriggerFailed:
+			fallthrough
+		case v1beta1.SavepointStateFailed:
+			fallthrough
+		default:
+			return nil, fmt.Errorf("invalid savepoint status: %v", observedSavepoint.State)
 		}
 	} else {
 		savepointStatus = nil

--- a/controllers/flinkcluster_util.go
+++ b/controllers/flinkcluster_util.go
@@ -162,7 +162,7 @@ func getNewSavepointStatus(jobID string, triggerID string, triggerReason string,
 	savepointStatus.TriggerReason = triggerReason
 	savepointStatus.Message = message
 	if triggerSuccess {
-		savepointStatus.State = v1beta1.SavepointStateProgressing
+		savepointStatus.State = v1beta1.SavepointStateInProgress
 	} else {
 		savepointStatus.State = v1beta1.SavepointStateTriggerFailed
 	}
@@ -215,7 +215,7 @@ func getSavepointEvent(status v1beta1.SavepointStatus) (eventType string, eventR
 		eventType = corev1.EventTypeWarning
 		eventReason = "SavepointFailed"
 		eventMessage = fmt.Sprintf("Failed to trigger savepoint %v: %v", status.TriggerReason, msg)
-	case v1beta1.SavepointStateProgressing:
+	case v1beta1.SavepointStateInProgress:
 		eventType = corev1.EventTypeNormal
 		eventReason = "SavepointTriggered"
 		eventMessage = fmt.Sprintf("Triggered savepoint %v: triggerID %v.", status.TriggerReason, status.TriggerID)

--- a/controllers/flinkcluster_util.go
+++ b/controllers/flinkcluster_util.go
@@ -190,6 +190,10 @@ func savepointTimeout(s *v1beta1.SavepointStatus) bool {
 }
 
 func getControlEvent(status v1beta1.FlinkClusterControlStatus) (eventType string, eventReason string, eventMessage string) {
+	var msg = status.Message
+	if len(msg) > 100 {
+		msg = msg[:100] + "..."
+	}
 	switch status.State {
 	case v1beta1.ControlStateProgressing:
 		eventType = corev1.EventTypeNormal
@@ -203,7 +207,7 @@ func getControlEvent(status v1beta1.FlinkClusterControlStatus) (eventType string
 		eventType = corev1.EventTypeWarning
 		eventReason = "ControlFailed"
 		if status.Message != "" {
-			eventMessage = fmt.Sprintf("User control %v failed: %v", status.Name, status.Message)
+			eventMessage = fmt.Sprintf("User control %v failed: %v", status.Name, msg)
 		} else {
 			eventMessage = fmt.Sprintf("User control %v failed", status.Name)
 		}
@@ -212,11 +216,15 @@ func getControlEvent(status v1beta1.FlinkClusterControlStatus) (eventType string
 }
 
 func getSavepointEvent(status v1beta1.SavepointStatus) (eventType string, eventReason string, eventMessage string) {
+	var msg = status.Message
+	if len(msg) > 100 {
+		msg = msg[:100] + "..."
+	}
 	switch status.State {
 	case SavepointStateTriggerFailed:
 		eventType = corev1.EventTypeWarning
 		eventReason = "SavepointFailed"
-		eventMessage = fmt.Sprintf("Failed to trigger savepoint %v: %v", status.TriggerReason, status.Message)
+		eventMessage = fmt.Sprintf("Failed to trigger savepoint %v: %v", status.TriggerReason, msg)
 	case SavepointStateProgressing:
 		if status.TriggerID == "" {
 			break
@@ -231,7 +239,7 @@ func getSavepointEvent(status v1beta1.SavepointStatus) (eventType string, eventR
 	case SavepointStateFailed:
 		eventType = corev1.EventTypeWarning
 		eventReason = "SavepointFailed"
-		eventMessage = fmt.Sprintf("Savepoint creation failed: %v", status.Message)
+		eventMessage = fmt.Sprintf("Savepoint creation failed: %v", msg)
 	}
 	return
 }


### PR DESCRIPTION
Currently when job cancellation is requested, savepoint creation and job cancellation is processed sequentially in the same iteration. In this PR, savepoint is triggered in the first iteration, then the job is stopped and deleted in the next iteration where the savepoint is completed.

Job cancellation status sample:
```
Status:
  ...
  ...
  Control:
    Name:            job-cancel
    State:           Succeeded
    Update Time:     2020-05-08T01:28:07+09:00
  Savepoint:
    Job ID:          944ff9266de15b2bc1d790b7341e5b8f
    State:           Succeeded
    Trigger ID:      558d4a49de7754349f776b5f42e613b3
    Trigger Reason:  for job-cancel
    Trigger Time:    2020-05-08T01:27:46+09:00
  State:             Stopped
Events:
  Type    Reason              Age   From           Message
  ----    ------              ----  ----           -------
  Normal  ControlRequested    28s   FlinkOperator  Requested new user control job-cancel
  Normal  SavepointTriggered  28s   FlinkOperator  Triggered savepoint for job-cancel: triggerID 558d4a49de7754349f776b5f42e613b3.
  Normal  SavepointCreated    9s    FlinkOperator  Successfully savepoint created
  Normal  ControlSucceeded    7s    FlinkOperator  Succesfully completed user control job-cancel
```