### PR TITLE
Support podTemplateAnnotations which injects custom annotations

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -212,7 +212,7 @@ type JobManagerSpec struct {
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
 
 	// JobManager Deployment pod template annotations.
-	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // TaskManagerPorts defines ports of TaskManager.
@@ -276,7 +276,7 @@ type TaskManagerSpec struct {
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
 
 	// TaskManager Deployment pod template annotations.
-	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // CleanupAction defines the action to take after job finishes.
@@ -369,7 +369,7 @@ type JobSpec struct {
 	CancelRequested *bool `json:"cancelRequested,omitempty"`
 
 	// Job pod template annotations.
-	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // FlinkClusterSpec defines the desired state of FlinkCluster

--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -210,6 +210,9 @@ type JobManagerSpec struct {
 	// Sidecar containers running alongside with the JobManager container in the
 	// pod.
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
+
+	// JobManager Deployment pod template annotations.
+	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
 }
 
 // TaskManagerPorts defines ports of TaskManager.
@@ -271,6 +274,9 @@ type TaskManagerSpec struct {
 	// Sidecar containers running alongside with the TaskManager container in the
 	// pod.
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
+
+	// TaskManager Deployment pod template annotations.
+	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
 }
 
 // CleanupAction defines the action to take after job finishes.
@@ -361,6 +367,9 @@ type JobSpec struct {
 	// `savePointsDir` is provided, a savepoint will be taken before stopping the
 	// job.
 	CancelRequested *bool `json:"cancelRequested,omitempty"`
+
+	// Job pod template annotations.
+	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
 }
 
 // FlinkClusterSpec defines the desired state of FlinkCluster

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1328,6 +1328,11 @@ spec:
                   description: 'Job parallelism, default: 1.'
                   format: int32
                   type: integer
+                podTemplateAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: Job pod template annotations.
+                  type: object
                 restartPolicy:
                   description: "Restart policy when the job fails, \"Never\" or \"FromSavepointOnFailure\",
                     default: \"Never\". \n \"Never\" means the operator will never
@@ -2692,6 +2697,11 @@ spec:
                     type: string
                   description: 'Selector which must match a node''s labels for the
                     JobManager pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: object
+                podTemplateAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: JobManager Deployment pod template annotations.
                   type: object
                 ports:
                   description: Ports.
@@ -5179,6 +5189,11 @@ spec:
                     type: string
                   description: 'Selector which must match a node''s labels for the
                     TaskManager pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: object
+                podTemplateAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: TaskManager Deployment pod template annotations.
                   type: object
                 ports:
                   description: Ports.

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1328,7 +1328,7 @@ spec:
                   description: 'Job parallelism, default: 1.'
                   format: int32
                   type: integer
-                podTemplateAnnotations:
+                podAnnotations:
                   additionalProperties:
                     type: string
                   description: Job pod template annotations.
@@ -2698,7 +2698,7 @@ spec:
                   description: 'Selector which must match a node''s labels for the
                     JobManager pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                   type: object
-                podTemplateAnnotations:
+                podAnnotations:
                   additionalProperties:
                     type: string
                   description: JobManager Deployment pod template annotations.
@@ -5190,7 +5190,7 @@ spec:
                   description: 'Selector which must match a node''s labels for the
                     TaskManager pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                   type: object
-                podTemplateAnnotations:
+                podAnnotations:
                   additionalProperties:
                     type: string
                   description: TaskManager Deployment pod template annotations.

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -224,7 +224,7 @@ func getDesiredJobManagerDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: jobManagerSpec.PodTemplateAnnotations,
+					Annotations: jobManagerSpec.PodAnnotations,
 				},
 				Spec: podSpec,
 			},
@@ -514,7 +514,7 @@ func getDesiredTaskManagerDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: taskManagerSpec.PodTemplateAnnotations,
+					Annotations: taskManagerSpec.PodAnnotations,
 				},
 				Spec: podSpec,
 			},
@@ -735,7 +735,7 @@ func getDesiredJob(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: jobSpec.PodTemplateAnnotations,
+					Annotations: jobSpec.PodAnnotations,
 				},
 				Spec: podSpec,
 			},

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -223,7 +223,8 @@ func getDesiredJobManagerDeployment(
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: jobManagerSpec.PodTemplateAnnotations,
 				},
 				Spec: podSpec,
 			},
@@ -512,7 +513,8 @@ func getDesiredTaskManagerDeployment(
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: taskManagerSpec.PodTemplateAnnotations,
 				},
 				Spec: podSpec,
 			},
@@ -731,8 +733,11 @@ func getDesiredJob(
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
-				Spec:       podSpec,
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labels,
+					Annotations: jobSpec.PodTemplateAnnotations,
+				},
+				Spec: podSpec,
 			},
 			BackoffLimit: &backoffLimit,
 		},

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -153,6 +153,9 @@ func TestGetDesiredClusterState(t *testing.T) {
 						},
 					},
 				},
+				PodTemplateAnnotations: map[string]string{
+					"example.com": "example",
+				},
 			},
 			JobManager: v1beta1.JobManagerSpec{
 				AccessScope: v1beta1.AccessScopeVPC,
@@ -184,6 +187,9 @@ func TestGetDesiredClusterState(t *testing.T) {
 				Tolerations:        tolerations,
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
 				MemoryOffHeapMin:   memoryOffHeapMin,
+				PodTemplateAnnotations: map[string]string{
+					"example.com": "example",
+				},
 			},
 			TaskManager: v1beta1.TaskManagerSpec{
 				Replicas: 42,
@@ -217,6 +223,9 @@ func TestGetDesiredClusterState(t *testing.T) {
 					{Name: "cache-volume", MountPath: "/cache"},
 				},
 				Tolerations: tolerations,
+				PodTemplateAnnotations: map[string]string{
+					"example.com": "example",
+				},
 			},
 			FlinkProperties: map[string]string{"taskmanager.numberOfTaskSlots": "1"},
 			EnvVars:         []corev1.EnvVar{{Name: "FOO", Value: "abc"}},
@@ -273,6 +282,9 @@ func TestGetDesiredClusterState(t *testing.T) {
 						"app":       "flink",
 						"cluster":   "flinkjobcluster-sample",
 						"component": "jobmanager",
+					},
+					Annotations: map[string]string{
+						"example.com": "example",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -522,6 +534,9 @@ func TestGetDesiredClusterState(t *testing.T) {
 						"cluster":   "flinkjobcluster-sample",
 						"component": "taskmanager",
 					},
+					Annotations: map[string]string{
+						"example.com": "example",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -662,7 +677,13 @@ func TestGetDesiredClusterState(t *testing.T) {
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "flink", "cluster": "flinkjobcluster-sample"},
+					Labels: map[string]string{
+						"app":     "flink",
+						"cluster": "flinkjobcluster-sample",
+					},
+					Annotations: map[string]string{
+						"example.com": "example",
+					},
 				},
 				Spec: v1.PodSpec{
 					InitContainers: []v1.Container{

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -153,7 +153,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 						},
 					},
 				},
-				PodTemplateAnnotations: map[string]string{
+				PodAnnotations: map[string]string{
 					"example.com": "example",
 				},
 			},
@@ -187,7 +187,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 				Tolerations:        tolerations,
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
 				MemoryOffHeapMin:   memoryOffHeapMin,
-				PodTemplateAnnotations: map[string]string{
+				PodAnnotations: map[string]string{
 					"example.com": "example",
 				},
 			},
@@ -223,7 +223,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 					{Name: "cache-volume", MountPath: "/cache"},
 				},
 				Tolerations: tolerations,
-				PodTemplateAnnotations: map[string]string{
+				PodAnnotations: map[string]string{
 					"example.com": "example",
 				},
 			},

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -36,6 +36,7 @@ FlinkCluster
         |__ nodeSelector
         |__ tolerations
         |__ sidecars
+        |__ podTemplateAnnotations
     |__ taskManager
         |__ replicas
         |__ ports
@@ -51,6 +52,7 @@ FlinkCluster
         |__ nodeSelector
         |__ tolerations
         |__ sidecars
+        |__ podTemplateAnnotations
     |__ job
         |__ jarFile
         |__ className
@@ -71,6 +73,7 @@ FlinkCluster
             |__ afterJobFails
             |__ afterJobCancelled
         |__ cancelRequested
+        |__ podTemplateAnnotations
     |__ envVars
     |__ flinkProperties
     |__ hadoopConfig
@@ -159,6 +162,8 @@ FlinkCluster
         See [more info](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)  
       * **sidecars** (optional): Sidecar containers running alongside with the JobManager container in the pod.
         See [more info](https://kubernetes.io/docs/concepts/containers/) about containers.  
+      * **podTemplateAnnotations** (optional): Pod template annotations for the JobManager deployment.
+        See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **taskManager** (required): TaskManager spec.
       * **replicas** (required): The number of TaskManager replicas.
       * **ports** (optional): Ports that TaskManager listening on.
@@ -191,6 +196,8 @@ FlinkCluster
         See [more info](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)  
       * **sidecars** (optional): Sidecar containers running alongside with the TaskManager container in the pod.
         See [more info](https://kubernetes.io/docs/concepts/containers/) about containers.
+      * **podTemplateAnnotations** (optional): Pod template annotations for the TaskManager deployment.
+        See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **job** (optional): Job spec. If specified, the cluster is a Flink job cluster; otherwise, it is a Flink
       session cluster.
       * **jarFile** (required): JAR file of the job. It could be a local file or remote URI, depending on which
@@ -227,6 +234,8 @@ FlinkCluster
           `enum("KeepCluster", "DeleteCluster", "DeleteTaskManager")`, default `"DeleteCluster"`.
       * **cancelRequested** (optional): Request the job to be cancelled. Only applies to running jobs. If
         `savePointsDir` is provided, a savepoint will be taken before stopping the job.
+      * **podTemplateAnnotations** (optional): Pod template annotations for the job.
+        See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **envVars** (optional): Environment variables shared by all JobManager, TaskManager and job containers.
     * **flinkProperties** (optional): Flink properties which are appened to flink-conf.yaml.
     * **hadoopConfig** (optional): Configs for Hadoop.

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -36,7 +36,7 @@ FlinkCluster
         |__ nodeSelector
         |__ tolerations
         |__ sidecars
-        |__ podTemplateAnnotations
+        |__ podAnnotations
     |__ taskManager
         |__ replicas
         |__ ports
@@ -52,7 +52,7 @@ FlinkCluster
         |__ nodeSelector
         |__ tolerations
         |__ sidecars
-        |__ podTemplateAnnotations
+        |__ podAnnotations
     |__ job
         |__ jarFile
         |__ className
@@ -73,7 +73,7 @@ FlinkCluster
             |__ afterJobFails
             |__ afterJobCancelled
         |__ cancelRequested
-        |__ podTemplateAnnotations
+        |__ podAnnotations
     |__ envVars
     |__ flinkProperties
     |__ hadoopConfig
@@ -162,7 +162,7 @@ FlinkCluster
         See [more info](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)  
       * **sidecars** (optional): Sidecar containers running alongside with the JobManager container in the pod.
         See [more info](https://kubernetes.io/docs/concepts/containers/) about containers.  
-      * **podTemplateAnnotations** (optional): Pod template annotations for the JobManager deployment.
+      * **podAnnotations** (optional): Pod template annotations for the JobManager deployment.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **taskManager** (required): TaskManager spec.
       * **replicas** (required): The number of TaskManager replicas.
@@ -196,7 +196,7 @@ FlinkCluster
         See [more info](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)  
       * **sidecars** (optional): Sidecar containers running alongside with the TaskManager container in the pod.
         See [more info](https://kubernetes.io/docs/concepts/containers/) about containers.
-      * **podTemplateAnnotations** (optional): Pod template annotations for the TaskManager deployment.
+      * **podAnnotations** (optional): Pod template annotations for the TaskManager deployment.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **job** (optional): Job spec. If specified, the cluster is a Flink job cluster; otherwise, it is a Flink
       session cluster.
@@ -234,7 +234,7 @@ FlinkCluster
           `enum("KeepCluster", "DeleteCluster", "DeleteTaskManager")`, default `"DeleteCluster"`.
       * **cancelRequested** (optional): Request the job to be cancelled. Only applies to running jobs. If
         `savePointsDir` is provided, a savepoint will be taken before stopping the job.
-      * **podTemplateAnnotations** (optional): Pod template annotations for the job.
+      * **podAnnotations** (optional): Pod template annotations for the job.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **envVars** (optional): Environment variables shared by all JobManager, TaskManager and job containers.
     * **flinkProperties** (optional): Flink properties which are appened to flink-conf.yaml.


### PR DESCRIPTION
To satisfy https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/268 , I want supports which accepts user defined annotations in k8s [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core). It should be useful to support flexible configurations.