### PR TITLE
Add Headless AccessScope to jobmanager service spec

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -58,6 +58,7 @@ const (
 	AccessScopeVPC      = "VPC"
 	AccessScopeExternal = "External"
 	AccessScopeNodePort = "NodePort"
+	AccessScopeHeadless = "Headless"
 )
 
 // JobRestartPolicy defines the restart policy when a job fails.

--- a/api/v1beta1/flinkcluster_validate.go
+++ b/api/v1beta1/flinkcluster_validate.go
@@ -296,6 +296,7 @@ func (v *Validator) validateJobManager(jmSpec *JobManagerSpec) error {
 	case AccessScopeVPC:
 	case AccessScopeExternal:
 	case AccessScopeNodePort:
+	case AccessScopeHeadless:
 	default:
 		return fmt.Errorf("invalid JobManager access scope: %v", jmSpec.AccessScope)
 	}

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -279,6 +279,11 @@ func getDesiredJobManagerService(
 		jobManagerService.Spec.Type = corev1.ServiceTypeLoadBalancer
 	case v1beta1.AccessScopeNodePort:
 		jobManagerService.Spec.Type = corev1.ServiceTypeNodePort
+	case v1beta1.AccessScopeHeadless:
+		// Headless services do not allocate any sort of VIP or LoadBalancer, and merely
+		// collect a set of Pod IPs that are assumed to be independently routable:
+		jobManagerService.Spec.Type = corev1.ServiceTypeClusterIP
+		jobManagerService.Spec.ClusterIP = "None"
 	default:
 		panic(fmt.Sprintf(
 			"Unknown service access cope: %v", jobManagerSpec.AccessScope))

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -143,8 +143,9 @@ FlinkCluster
       If empty, no batch scheduling is enabled.
     * **jobManager** (required): JobManager spec.
       * **accessScope** (optional): Access scope of the JobManager service. `enum("Cluster", "VPC", "External", 
-      "NodePort")`.`Cluster`: accessible from within the same cluster; `VPC`: accessible from within the same VPC; 
-      `External`:accessible from the internet. `NodePort`: accessible through node port.  
+      "NodePort", "Headless")`. `Cluster`: accessible from within the same cluster; `VPC`: accessible from within the same VPC; 
+      `External`: accessible from the internet. `NodePort`: accessible through node port; `Headless`: pod IPs assumed to 
+      be routable and advertised directly with `clusterIP: None`.  
       Currently `VPC` and `External` are only available for GKE.
       * **ports** (optional): Ports that JobManager listening on.
         * **rpc** (optional): RPC port, default: 6123.


### PR DESCRIPTION
# What?

Adds `Headless` as a valid enumerated option for the `spec.jobmanager.accessScope` property in the CRD, in order to generate a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) for the jobmanager.

# Why?

This is useful when, for example, your pod network is directly routable and you'd like to use `SRV` records (or `A` round-robin) to discover the underlying pod IPs. In this kind of topology, it is possible to avoid ingress completely yet still communicate with the jobmanager from outside the Kubernetes cluster.

Thanks!