### PR TITLE
Support for EnvFromSource in cluster spec

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -413,6 +413,10 @@ type FlinkClusterSpec struct {
 	// containers.
 	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
+	// Environment variables injected from a source, shared by all JobManager,
+	// TaskManager and job containers.
+	EnvFroms []corev1.EnvFromSource `json:"envFrom,omitempty"`
+
 	// Flink properties which are appened to flink-conf.yaml.
 	FlinkProperties map[string]string `json:"flinkProperties,omitempty"`
 

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -187,6 +187,7 @@ func getDesiredJobManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       jobManagerSpec.Resources,
 		Env:             envVars,
+		EnvFrom:         flinkCluster.Spec.EnvFroms,
 		VolumeMounts:    volumeMounts,
 	}}
 
@@ -477,6 +478,7 @@ func getDesiredTaskManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       taskManagerSpec.Resources,
 		Env:             envVars,
+		EnvFrom:         flinkCluster.Spec.EnvFroms,
 		VolumeMounts:    volumeMounts,
 	}}
 	containers = append(containers, taskManagerSpec.Sidecars...)

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -239,6 +239,10 @@ func TestGetDesiredClusterState(t *testing.T) {
 			},
 			FlinkProperties: map[string]string{"taskmanager.numberOfTaskSlots": "1"},
 			EnvVars:         []corev1.EnvVar{{Name: "FOO", Value: "abc"}},
+			EnvFroms:        []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "FOOMAP",
+			}}}},
 			HadoopConfig: &v1beta1.HadoopConfig{
 				ConfigMapName: "hadoop-configmap",
 				MountPath:     "/etc/hadoop/conf",
@@ -345,6 +349,15 @@ func TestGetDesiredClusterState(t *testing.T) {
 								{
 									Name:  "FOO",
 									Value: "abc",
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "FOOMAP",
+										},
+									},
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -599,6 +612,15 @@ func TestGetDesiredClusterState(t *testing.T) {
 								{
 									Name:  "FOO",
 									Value: "abc",
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "FOOMAP",
+										},
+									},
 								},
 							},
 							Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
This new feature is to support EnvFromSource in cluster spec.
Prerequisites：
none
Why this feature:
Currently spec allows defining env vars but not env from source, for configmaps and secrets.
Solution:
In the Spec of FlinkCluster, we introduce a new property, "envFrom", of type []corev1.EnvFromSource.