### PR TITLE
Support for EnvFromSource in cluster spec

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -413,6 +413,10 @@ type FlinkClusterSpec struct {
 	// containers.
 	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
+	// Environment variables injected from a source, shared by all JobManager,
+	// TaskManager and job containers.
+	EnvFroms []corev1.EnvFromSource `json:"envFrom,omitempty"`
+
 	// Flink properties which are appened to flink-conf.yaml.
 	FlinkProperties map[string]string `json:"flinkProperties,omitempty"`
 

--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -415,7 +415,7 @@ type FlinkClusterSpec struct {
 
 	// Environment variables injected from a source, shared by all JobManager,
 	// TaskManager and job containers.
-	EnvFroms []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Flink properties which are appened to flink-conf.yaml.
 	FlinkProperties map[string]string `json:"flinkProperties,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -188,6 +188,13 @@ func (in *FlinkClusterSpec) DeepCopyInto(out *FlinkClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvFroms != nil {
+		in, out := &in.EnvFroms, &out.EnvFroms
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.FlinkProperties != nil {
 		in, out := &in.FlinkProperties, &out.FlinkProperties
 		*out = make(map[string]string, len(*in))

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -188,8 +188,8 @@ func (in *FlinkClusterSpec) DeepCopyInto(out *FlinkClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.EnvFroms != nil {
-		in, out := &in.EnvFroms, &out.EnvFroms
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
 		*out = make([]v1.EnvFromSource, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -30,6 +30,27 @@ spec:
           properties:
             batchSchedulerName:
               type: string
+            envFrom:
+              items:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    type: object
+                  prefix:
+                    type: string
+                  secretRef:
+                    properties:
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    type: object
+                type: object
+              type: array
             envVars:
               items:
                 properties:

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -187,7 +187,7 @@ func getDesiredJobManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       jobManagerSpec.Resources,
 		Env:             envVars,
-		EnvFrom:         flinkCluster.Spec.EnvFroms,
+		EnvFrom:         flinkCluster.Spec.EnvFrom,
 		VolumeMounts:    volumeMounts,
 	}}
 
@@ -478,7 +478,7 @@ func getDesiredTaskManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       taskManagerSpec.Resources,
 		Env:             envVars,
-		EnvFrom:         flinkCluster.Spec.EnvFroms,
+		EnvFrom:         flinkCluster.Spec.EnvFrom,
 		VolumeMounts:    volumeMounts,
 	}}
 	containers = append(containers, taskManagerSpec.Sidecars...)

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -187,6 +187,7 @@ func getDesiredJobManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       jobManagerSpec.Resources,
 		Env:             envVars,
+		EnvFrom:         flinkCluster.Spec.EnvFroms,
 		VolumeMounts:    volumeMounts,
 	}}
 
@@ -477,6 +478,7 @@ func getDesiredTaskManagerDeployment(
 		ReadinessProbe:  &readinessProbe,
 		Resources:       taskManagerSpec.Resources,
 		Env:             envVars,
+		EnvFrom:         flinkCluster.Spec.EnvFroms,
 		VolumeMounts:    volumeMounts,
 	}}
 	containers = append(containers, taskManagerSpec.Sidecars...)

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -239,7 +239,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 			},
 			FlinkProperties: map[string]string{"taskmanager.numberOfTaskSlots": "1"},
 			EnvVars:         []corev1.EnvVar{{Name: "FOO", Value: "abc"}},
-			EnvFroms:        []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{
+			EnvFrom:        []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "FOOMAP",
 			}}}},

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -239,6 +239,10 @@ func TestGetDesiredClusterState(t *testing.T) {
 			},
 			FlinkProperties: map[string]string{"taskmanager.numberOfTaskSlots": "1"},
 			EnvVars:         []corev1.EnvVar{{Name: "FOO", Value: "abc"}},
+			EnvFroms:        []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "FOOMAP",
+			}}}},
 			HadoopConfig: &v1beta1.HadoopConfig{
 				ConfigMapName: "hadoop-configmap",
 				MountPath:     "/etc/hadoop/conf",
@@ -345,6 +349,15 @@ func TestGetDesiredClusterState(t *testing.T) {
 								{
 									Name:  "FOO",
 									Value: "abc",
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "FOOMAP",
+										},
+									},
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -599,6 +612,15 @@ func TestGetDesiredClusterState(t *testing.T) {
 								{
 									Name:  "FOO",
 									Value: "abc",
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "FOOMAP",
+										},
+									},
 								},
 							},
 							Resources: corev1.ResourceRequirements{

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -78,6 +78,7 @@ FlinkCluster
         |__ cancelRequested
         |__ podAnnotations
     |__ envVars
+    |__ envFrom
     |__ flinkProperties
     |__ hadoopConfig
         |__ configMapName
@@ -266,6 +267,7 @@ FlinkCluster
       * **podAnnotations** (optional): Pod template annotations for the job.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
     * **envVars** (optional): Environment variables shared by all JobManager, TaskManager and job containers.
+    * **envFrom** (optional): Environment variables from ConfigMaps or Secrets shared by all JobManager, TaskManager and job containers.
     * **flinkProperties** (optional): Flink properties which are appened to flink-conf.yaml.
     * **hadoopConfig** (optional): Configs for Hadoop.
       * **configMapName**: The name of the ConfigMap which holds the Hadoop config files. The ConfigMap must be in the


### PR DESCRIPTION
This new feature is to support EnvFromSource in cluster spec.
Prerequisites：
none
Why this feature:
Currently spec allows defining env vars but not env from source, for configmaps and secrets.
Solution:
In the Spec of FlinkCluster, we introduce a new property, "envFrom", of type []corev1.EnvFromSource.