### PR TITLE
Set EnvFrom in Job Spec

### DIFF
--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -693,6 +693,7 @@ func getDesiredJob(
 				ImagePullPolicy: imageSpec.PullPolicy,
 				Args:            jobArgs,
 				Env:             envVars,
+				EnvFrom:         flinkCluster.Spec.EnvFrom,
 				VolumeMounts:    volumeMounts,
 				Resources:       jobSpec.Resources,
 			},

--- a/controllers/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster_converter_test.go
@@ -769,6 +769,15 @@ func TestGetDesiredClusterState(t *testing.T) {
 								},
 								{Name: "FOO", Value: "abc"},
 							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "FOOMAP",
+										},
+									},
+								},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    resource.MustParse("100m"),


### PR DESCRIPTION
I'd neglected to add the `EnvFrom` to the job container spec in https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/pull/283