### PR TITLE
Support beam job server manifest on 1.16+

### DIFF
--- a/examples/beam/with_job_server/beam_job_server.yaml
+++ b/examples/beam/with_job_server/beam_job_server.yaml
@@ -1,8 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: beam-job-server
 spec:
+  selector:
+    matchLabels:
+      app: beam-job-server
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Current beam_job_server.yaml can not be deployed to K8s 1.16 and above. the major reason is

1. `apps/v1beta` has been deprecated, we need to migrate to `apps/v1`
```
error: unable to recognize "beam_job_server.yaml": no matches for kind "Deployment" in version "apps/v1beta1"
```

2. deployment doesn't have selector which violates deployment spec. 
```
error: error validating "beam_job_server.yaml": error validating data: ValidationError(Deployment.spec): 
missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

This PR helps to make it deploy on 1.16+.