### PR TITLE
Expose SecurityContext in FlinkClusterSpec

### DIFF
--- a/api/v1beta1/flinkcluster_default_test.go
+++ b/api/v1beta1/flinkcluster_default_test.go
@@ -81,6 +81,7 @@ func TestSetDefault(t *testing.T) {
 				MemoryOffHeapMin:   defaultMemoryOffHeapMin,
 				Volumes:            nil,
 				VolumeMounts:       nil,
+				SecurityContext:    nil,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -93,6 +94,7 @@ func TestSetDefault(t *testing.T) {
 				MemoryOffHeapRatio: &defaultMemoryOffHeapRatio,
 				MemoryOffHeapMin:   defaultMemoryOffHeapMin,
 				Volumes:            nil,
+				SecurityContext:    nil,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &defaultJobAllowNonRestoredState,
@@ -104,6 +106,7 @@ func TestSetDefault(t *testing.T) {
 					AfterJobFails:     "KeepCluster",
 					AfterJobCancelled: "DeleteCluster",
 				},
+				SecurityContext: nil,
 			},
 			FlinkProperties: nil,
 			HadoopConfig: &HadoopConfig{
@@ -138,6 +141,11 @@ func TestSetNonDefault(t *testing.T) {
 	var jobManagerIngressTLSUse = true
 	var memoryOffHeapRatio = int32(50)
 	var memoryOffHeapMin = resource.MustParse("600M")
+	var securityContextUserGroup = int64(9999)
+	var securityContext = corev1.PodSecurityContext{
+		RunAsUser:  &securityContextUserGroup,
+		RunAsGroup: &securityContextUserGroup,
+	}
 	var cluster = FlinkCluster{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
@@ -164,6 +172,7 @@ func TestSetNonDefault(t *testing.T) {
 				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 				VolumeMounts:       nil,
+				SecurityContext:    &securityContext,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -176,12 +185,14 @@ func TestSetNonDefault(t *testing.T) {
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
 				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
+				SecurityContext:    &securityContext,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &jobAllowNonRestoredState,
 				Parallelism:           &jobParallelism,
 				NoLoggingToStdout:     &jobNoLoggingToStdout,
 				RestartPolicy:         &jobRestartPolicy,
+				SecurityContext:       &securityContext,
 				CleanupPolicy: &CleanupPolicy{
 					AfterJobSucceeds:  "DeleteTaskManagers",
 					AfterJobFails:     "DeleteCluster",
@@ -225,6 +236,7 @@ func TestSetNonDefault(t *testing.T) {
 				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
 				VolumeMounts:       nil,
+				SecurityContext:    &securityContext,
 			},
 			TaskManager: TaskManagerSpec{
 				Replicas: 0,
@@ -237,12 +249,14 @@ func TestSetNonDefault(t *testing.T) {
 				MemoryOffHeapRatio: &memoryOffHeapRatio,
 				MemoryOffHeapMin:   memoryOffHeapMin,
 				Volumes:            nil,
+				SecurityContext:    &securityContext,
 			},
 			Job: &JobSpec{
 				AllowNonRestoredState: &jobAllowNonRestoredState,
 				Parallelism:           &jobParallelism,
 				NoLoggingToStdout:     &jobNoLoggingToStdout,
 				RestartPolicy:         &jobRestartPolicy,
+				SecurityContext:       &securityContext,
 				CleanupPolicy: &CleanupPolicy{
 					AfterJobSucceeds:  "DeleteTaskManagers",
 					AfterJobFails:     "DeleteCluster",

--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -222,6 +222,9 @@ type JobManagerSpec struct {
 	// JobManager Deployment pod template annotations.
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 
+	// SecurityContext of the JM pod.
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+
 	// JobManager Deployment pod template labels.
 	PodLabels map[string]string `json:"podLabels,omitempty"`
 }
@@ -291,6 +294,9 @@ type TaskManagerSpec struct {
 
 	// TaskManager Deployment pod template annotations.
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	// SecurityContext of the TM pod.
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	// TaskManager Deployment pod template labels.
 	PodLabels map[string]string `json:"podLabels,omitempty"`
@@ -396,6 +402,8 @@ type JobSpec struct {
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 // FlinkClusterSpec defines the desired state of FlinkCluster

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -753,6 +753,59 @@ spec:
                   type: integer
                 savepointsDir:
                   type: string
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
                 volumeMounts:
                   items:
                     properties:
@@ -1999,6 +2052,59 @@ spec:
                         - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
                       type: object
                   type: object
                 sidecars:
@@ -3787,6 +3893,59 @@ spec:
                         - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
                       type: object
                   type: object
                 sidecars:

--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -37,8 +37,5 @@ spec:
     className: org.apache.flink.streaming.examples.wordcount.WordCount
     args: ["--input", "./README.txt"]
     parallelism: 2
-    securityContext:
-      runAsUser: 9999
-      runAsGroup: 9999
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"

--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -37,5 +37,8 @@ spec:
     className: org.apache.flink.streaming.examples.wordcount.WordCount
     args: ["--input", "./README.txt"]
     parallelism: 2
+    securityContext:
+      runAsUser: 9999
+      runAsGroup: 9999
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
@@ -22,6 +22,9 @@ spec:
     pullPolicy: Always
   jobManager:
     accessScope: Cluster
+    securityContext:
+      runAsUser: 9999
+      runAsGroup: 9999
     ports:
       ui: 8081
     resources:
@@ -30,6 +33,9 @@ spec:
         cpu: "200m"
   taskManager:
     replicas: 1
+    securityContext:
+      runAsUser: 9999
+      runAsGroup: 9999
     resources:
       limits:
         memory: "1024Mi"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
@@ -33,9 +33,6 @@ spec:
         cpu: "200m"
   taskManager:
     replicas: 1
-    securityContext:
-      runAsUser: 9999
-      runAsGroup: 9999
     resources:
       limits:
         memory: "1024Mi"

--- a/controllers/flinkcluster_converter.go
+++ b/controllers/flinkcluster_converter.go
@@ -100,6 +100,7 @@ func getDesiredJobManagerDeployment(
 	var podLabels = getComponentLabels(*flinkCluster, "jobmanager")
 	podLabels = mergeLabels(podLabels, jobManagerSpec.PodLabels)
 	var deploymentLabels = mergeLabels(podLabels, getRevisionHashLabels(flinkCluster.Status))
+	var securityContext = jobManagerSpec.SecurityContext
 	// Make Volume, VolumeMount to use configMap data for flink-conf.yaml, if flinkProperties is provided.
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -201,8 +202,8 @@ func getDesiredJobManagerDeployment(
 		NodeSelector:     jobManagerSpec.NodeSelector,
 		Tolerations:      jobManagerSpec.Tolerations,
 		ImagePullSecrets: imageSpec.PullSecrets,
+		SecurityContext:  securityContext,
 	}
-
 	var jobManagerDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       clusterNamespace,
@@ -392,6 +393,9 @@ func getDesiredTaskManagerDeployment(
 	var podLabels = getComponentLabels(*flinkCluster, "taskmanager")
 	podLabels = mergeLabels(podLabels, taskManagerSpec.PodLabels)
 	var deploymentLabels = mergeLabels(podLabels, getRevisionHashLabels(flinkCluster.Status))
+
+	var securityContext = taskManagerSpec.SecurityContext
+
 	// Make Volume, VolumeMount to use configMap data for flink-conf.yaml
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -492,6 +496,7 @@ func getDesiredTaskManagerDeployment(
 		NodeSelector:     taskManagerSpec.NodeSelector,
 		Tolerations:      taskManagerSpec.Tolerations,
 		ImagePullSecrets: imageSpec.PullSecrets,
+		SecurityContext:  securityContext,
 	}
 	var taskManagerDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -628,6 +633,8 @@ func getDesiredJob(
 	}
 	jobArgs = append(jobArgs, "--detached")
 
+	var securityContext = jobSpec.SecurityContext
+
 	var envVars = []corev1.EnvVar{}
 
 	// If the JAR file is remote, put the URI in the env variable
@@ -700,6 +707,7 @@ func getDesiredJob(
 		RestartPolicy:    corev1.RestartPolicyNever,
 		Volumes:          volumes,
 		ImagePullSecrets: imageSpec.PullSecrets,
+		SecurityContext:  securityContext,
 	}
 
 	// Disable the retry mechanism of k8s Job, all retires should be initiated

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -198,6 +198,8 @@ FlinkCluster
       * **podAnnotations** (optional): Pod template annotations for the JobManager deployment.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
       * **podLabels** (optional): Pod template labels for the JobManager deployment.
+      * **securityContext** (optional): PodSecurityContext for the JobManager pod. 
+      See [more info](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
     * **taskManager** (required): TaskManager spec.
       * **replicas** (required): The number of TaskManager replicas.
       * **ports** (optional): Ports that TaskManager listening on.
@@ -235,6 +237,8 @@ FlinkCluster
       * **podAnnotations** (optional): Pod template annotations for the TaskManager deployment.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
       * **podLabels** (optional): Pod template labels for the TaskManager deployment.
+      * **securityContext** (optional): PodSecurityContext for the TaskManager pods. 
+        See [more info](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
     * **job** (optional): Job spec. If specified, the cluster is a Flink job cluster; otherwise, it is a Flink
       session cluster.
       * **jarFile** (required): JAR file of the job. It could be a local file or remote URI, depending on which
@@ -276,6 +280,8 @@ FlinkCluster
       * **podAnnotations** (optional): Pod template annotations for the job.
         See [more info](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) about annotations.
       * **podLabels** (optional): Pod template labels for the job.
+      * **securityContext** (optional): PodSecurityContext for the Job pod. 
+            See [more info](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
     * **envVars** (optional): Environment variables shared by all JobManager, TaskManager and job containers.
     * **envFrom** (optional): Environment variables from ConfigMaps or Secrets shared by all JobManager, TaskManager and job containers.
     * **flinkProperties** (optional): Flink properties which are appened to flink-conf.yaml.

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -40,6 +40,7 @@ FlinkCluster
         |__ sidecars
         |__ podAnnotations
         |__ podLabels
+        |__ securityContext
     |__ taskManager
         |__ replicas
         |__ ports
@@ -58,6 +59,7 @@ FlinkCluster
         |__ sidecars
         |__ podAnnotations
         |__ podLabels
+        |__ securityContext
     |__ job
         |__ jarFile
         |__ className
@@ -80,6 +82,7 @@ FlinkCluster
         |__ cancelRequested
         |__ podAnnotations
         |__ podLabels
+        |__ securityContext
     |__ envVars
     |__ envFrom
     |__ flinkProperties

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -466,3 +466,22 @@ The default Flink docker entrypoint expects this directory to contain two files:
 
 An example of using this parameter to make logs visible in both the Flink UI and on stdout 
 [can be found here](../examples/log_config.yaml).
+
+### Control Security and Permissions in Pods
+You can set various security-related attributes of the JobManager, TaskManager, and Job Pods using a 
+[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core)
+object. It is possible to run the entrypoint of the container process as a different user or group,
+and to modify ownership of mounted volumes. 
+
+You can set the SecurityContext in the FlinkCluster spec, within the JobManager, TaskManager, and Job fields, like this: 
+```yaml
+taskManager:
+  ...
+  securityContext:
+    runAsUser: 9999
+    runAsGroup: 1000
+    fsGroup: 2000
+```
+You can set different SecurityContexts for the TaskManager, JobManager deployments and the Job, but all TaskManager pods
+will share the same one.
+Examples and explanations of the available options can be found [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).


### PR DESCRIPTION
Expose the PodSecurityContext for JobManager, TaskManager, and Job pods in the FlinkClusterSpec.
This lets us run them as the Flink user, as mentioned in https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/312
