### PR TITLE
add ns create flag

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -50,7 +50,7 @@ main() {
     kustomize build flink-on-k8s-operator/config/default | tee flink-operator.yaml
     sed -i '1s/^/{{- if .Values.rbac.create }}\n/' flink-operator.yaml
     sed -i -e "\$a{{- end }}\n" flink-operator.yaml
-    sed -i 's/flink-operator-system/{{ .Values.flinkOperatorNamespace }}/g' flink-operator.yaml
+    sed -i 's/flink-operator-system/{{ .Values.flinkOperatorNamespace.name }}/g' flink-operator.yaml
     sed -i 's/replicas: 1/replicas: {{ .Values.replicas }}/g' flink-operator.yaml
     sed -i "s/$IMG/{{ .Values.operatorImage.name }}/g" flink-operator.yaml
     mv flink-operator.yaml helm-chart/flink-operator/templates/flink-operator.yaml

--- a/helm-chart/flink-operator/README.md
+++ b/helm-chart/flink-operator/README.md
@@ -32,7 +32,7 @@ If you're installing the operator into a preexisting namespace, make sure to cha
     If you're installing the chart into a preexisting namespace, make sure to set the namespace name and instruct the chart not create one like so:  
 
     ```bash
-    helm install --name [RELEASE_NAME] . --set operatorImage.name=[IMAGE_NAME],flinkOperatorNamespace.name=[NAMESPACE_NAME],flinkOperatorNamespace.name=false
+    helm install --name [RELEASE_NAME] . --set operatorImage.name=[IMAGE_NAME],flinkOperatorNamespace.name=[NAMESPACE_NAME],flinkOperatorNamespace.create=false
     ```
 ## Uninstalling the Chart
 

--- a/helm-chart/flink-operator/README.md
+++ b/helm-chart/flink-operator/README.md
@@ -8,7 +8,8 @@ The instructions to install the Flink operator chart:
 
 1. Prepare a Flink operator image. You can either use a released image e.g., `gcr.io/flink-operator/flink-operator:latest` or follow the instructions [here](https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/blob/master/docs/developer_guide.md#build-and-push-docker-image) to build and push an image from the source code.
 
-2. Run the bash script `update_template.sh` to update the manifest files in templates from the Flink operator source repo (This step is only required if you want to install from the local chart repo).
+2. Run the bash script `update_template.sh` to update the manifest files in templates from the Flink operator source repo (This step is only required if you want to install from the local chart repo).  
+If you're installing the operator into a preexisting namespace, make sure to change `flink-operator-system` in the `update_template.sh` script to your namespace.
 
 3. Register CRD - Don't manually register CRD unless helm install below fails (You can skip this step if your helm version is v3). 
     
@@ -28,6 +29,11 @@ The instructions to install the Flink operator chart:
     helm install --name [RELEASE_NAME] . --set operatorImage.name=[IMAGE_NAME]
     ```
 
+    If you're installing the chart into a preexisting namespace, make sure to set the namespace name and instruct the chart not create one like so:  
+
+    ```bash
+    helm install --name [RELEASE_NAME] . --set operatorImage.name=[IMAGE_NAME],flinkOperatorNamespace.name=[NAMESPACE_NAME],flinkOperatorNamespace.name=false
+    ```
 ## Uninstalling the Chart
 
 To uninstall your release:

--- a/helm-chart/flink-operator/README.md
+++ b/helm-chart/flink-operator/README.md
@@ -9,6 +9,9 @@ The instructions to install the Flink operator chart:
 1. Prepare a Flink operator image. You can either use a released image e.g., `gcr.io/flink-operator/flink-operator:latest` or follow the instructions [here](https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/blob/master/docs/developer_guide.md#build-and-push-docker-image) to build and push an image from the source code.
 
 2. Run the bash script `update_template.sh` to update the manifest files in templates from the Flink operator source repo (This step is only required if you want to install from the local chart repo).  
+    You can set the following env vars to customize the script's behaviour -
+    * `export IMG=<image-name>` - Operator image, defaults to `flink-operator:latest`
+    * `export NS=<namespace-name>` - Namespace to install the operator in, defaults to `flink-operator-system`
 
 3. Register CRD - Don't manually register CRD unless helm install below fails (You can skip this step if your helm version is v3). 
     

--- a/helm-chart/flink-operator/README.md
+++ b/helm-chart/flink-operator/README.md
@@ -9,7 +9,6 @@ The instructions to install the Flink operator chart:
 1. Prepare a Flink operator image. You can either use a released image e.g., `gcr.io/flink-operator/flink-operator:latest` or follow the instructions [here](https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/blob/master/docs/developer_guide.md#build-and-push-docker-image) to build and push an image from the source code.
 
 2. Run the bash script `update_template.sh` to update the manifest files in templates from the Flink operator source repo (This step is only required if you want to install from the local chart repo).  
-If you're installing the operator into a preexisting namespace, make sure to change `flink-operator-system` in the `update_template.sh` script to your namespace.
 
 3. Register CRD - Don't manually register CRD unless helm install below fails (You can skip this step if your helm version is v3). 
     

--- a/helm-chart/flink-operator/templates/flink-operator.yaml
+++ b/helm-chart/flink-operator/templates/flink-operator.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.rbac.create }}
+{{- if .Values.flinkOperatorNamespace.create }}
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: {{ .Values.flinkOperatorNamespace }}
+  name: {{ .Values.flinkOperatorNamespace.name }}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
@@ -16,7 +18,7 @@ webhooks:
     caBundle: Cg==
     service:
       name: flink-operator-webhook-service
-      namespace: {{ .Values.flinkOperatorNamespace }}
+      namespace: {{ .Values.flinkOperatorNamespace.name }}
       path: /mutate-flinkoperator-k8s-io-v1beta1-flinkcluster
   failurePolicy: Fail
   name: mflinkcluster.flinkoperator.k8s.io
@@ -35,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: flink-operator-leader-election-role
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 rules:
 - apiGroups:
   - ""
@@ -256,7 +258,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flink-operator-leader-election-rolebinding
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -264,7 +266,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -277,7 +279,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -290,7 +292,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 ---
 apiVersion: v1
 kind: Service
@@ -302,7 +304,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: flink-operator-controller-manager-metrics-service
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 spec:
   ports:
   - name: https
@@ -315,7 +317,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flink-operator-webhook-service
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 spec:
   ports:
   - port: 443
@@ -330,7 +332,7 @@ metadata:
     app: flink-operator
     control-plane: controller-manager
   name: flink-operator-controller-manager
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -359,7 +361,7 @@ spec:
         - --watch-namespace=
         command:
         - /flink-operator
-        image: {{ .Values.operatorImage.name }}
+        image: {{ .Values.operatorImage.name.name }}
         imagePullPolicy: {{ .Values.operatorImage.pullPolicy }}
         name: flink-operator
         ports:
@@ -394,7 +396,7 @@ webhooks:
     caBundle: Cg==
     service:
       name: flink-operator-webhook-service
-      namespace: {{ .Values.flinkOperatorNamespace }}
+      namespace: {{ .Values.flinkOperatorNamespace.name }}
       path: /validate-flinkoperator-k8s-io-v1beta1-flinkcluster
   failurePolicy: Fail
   name: vflinkcluster.flinkoperator.k8s.io

--- a/helm-chart/flink-operator/templates/generate-cert.yaml
+++ b/helm-chart/flink-operator/templates/generate-cert.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: cert-configmap
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
   labels:
     app.kubernetes.io/name: flink-operator
     app.kubernetes.io/component: cert-configmap
@@ -13,7 +13,7 @@ data:
     set -euxo pipefail
     service="flink-operator-webhook-service"
     secret="webhook-server-cert"
-    namespace={{ .Values.flinkOperatorNamespace }}
+    namespace={{ .Values.flinkOperatorNamespace.name }}
     csrName="${service}.${namespace}"
     tmpdir="$(mktemp -d)"
     echo "Creating certs in tmpdir ${tmpdir} "
@@ -59,7 +59,7 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: webhook-configmap
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
   labels:
     app.kubernetes.io/name: flink-operator
     app.kubernetes.io/component: webhook-configmap
@@ -75,7 +75,7 @@ data:
         caBundle: $CA_PEM_B64
         service:
           name: flink-operator-webhook-service
-          namespace: {{ .Values.flinkOperatorNamespace }}
+          namespace: {{ .Values.flinkOperatorNamespace.name }}
           path: /mutate-flinkoperator-k8s-io-v1beta1-flinkcluster
       failurePolicy: Fail
       name: mflinkcluster.flinkoperator.k8s.io
@@ -100,7 +100,7 @@ data:
         caBundle: $CA_PEM_B64
         service:
           name: flink-operator-webhook-service
-          namespace: {{ .Values.flinkOperatorNamespace }}
+          namespace: {{ .Values.flinkOperatorNamespace.name }}
           path: /validate-flinkoperator-k8s-io-v1beta1-flinkcluster
       failurePolicy: Fail
       name: vflinkcluster.flinkoperator.k8s.io
@@ -120,7 +120,7 @@ kind: Job
 metadata:
   annotations:
   name: cert-job
-  namespace: {{ .Values.flinkOperatorNamespace }}
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
   labels:
     app.kubernetes.io/name: flink-operator
     app.kubernetes.io/component: cert-job

--- a/helm-chart/flink-operator/update_template.sh
+++ b/helm-chart/flink-operator/update_template.sh
@@ -7,7 +7,7 @@ sed -i '/- \.\.\/crd/d' ../../config/default/kustomization.yaml
 kubectl kustomize ../../config/default | tee templates/flink-operator.yaml
 sed -i '1s/^/{{- if .Values.rbac.create }}\n/' templates/flink-operator.yaml
 sed -i -e "\$a{{- end }}\n" templates/flink-operator.yaml
-sed -i 's/flink-operator-system/{{ .Values.flinkOperatorNamespace }}/g' templates/flink-operator.yaml
+sed -i 's/flink-operator-system/{{ .Values.flinkOperatorNamespace.name }}/g' templates/flink-operator.yaml
 sed -i 's/replicas: 1/replicas: {{ .Values.replicas }}/g' templates/flink-operator.yaml
 sed -i "s/$IMG/{{ .Values.operatorImage.name }}/g" templates/flink-operator.yaml
 sed -i 's/--watch-namespace=/--watch-namespace={{ .Values.watchNamespace }}/' templates/flink-operator.yaml

--- a/helm-chart/flink-operator/update_template.sh
+++ b/helm-chart/flink-operator/update_template.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 IMG="${IMG:-flink-operator:latest}"
+NS="${NS:-flink-operator-system}"
 
 sed -e 's#image: .*#image: '"${IMG}"'#' ../../config/default/manager_image_patch.template >../../config/default/manager_image_patch.yaml
 sed -i '/- \.\.\/crd/d' ../../config/default/kustomization.yaml
 kubectl kustomize ../../config/default | tee templates/flink-operator.yaml
 sed -i '1s/^/{{- if .Values.rbac.create }}\n/' templates/flink-operator.yaml
 sed -i -e "\$a{{- end }}\n" templates/flink-operator.yaml
-sed -i 's/flink-operator-system/{{ .Values.flinkOperatorNamespace.name }}/g' templates/flink-operator.yaml
+sed -i 's/'"${NS}"'/{{ .Values.flinkOperatorNamespace.name }}/g' templates/flink-operator.yaml
 sed -i 's/replicas: 1/replicas: {{ .Values.replicas }}/g' templates/flink-operator.yaml
 sed -i "s/$IMG/{{ .Values.operatorImage.name }}/g" templates/flink-operator.yaml
 sed -i 's/--watch-namespace=/--watch-namespace={{ .Values.watchNamespace }}/' templates/flink-operator.yaml

--- a/helm-chart/flink-operator/values.yaml
+++ b/helm-chart/flink-operator/values.yaml
@@ -1,5 +1,7 @@
 # K8s namespace where Flink operator to be deployed
-flinkOperatorNamespace: "flink-operator-system"
+flinkOperatorNamespace: 
+  name: "flink-operator-system"
+  create: true
 
 # Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.
 watchNamespace:


### PR DESCRIPTION
Signed-off-by: Yaron Idan <yaronidan@gmail.com>

Closes #348 

I chose to stick with the convention seen in the rest of the chart and move the namespace name and create flag under the `flinkOperatorNamespace` key. 
This choice is a breaking change for anyone using a non-default namespace name, if you think it's too much I can leave both keys in the root level of the values file.