### PR TITLE
Hardcoded job.args value in flink-job-cluster helm chart #367

### DIFF
--- a/helm-chart/flink-job-cluster/templates/flinkjobcluster.yaml
+++ b/helm-chart/flink-job-cluster/templates/flinkjobcluster.yaml
@@ -56,9 +56,20 @@ spec:
   job:
     jarFile: {{ .Values.job.jarFile }}
     className: {{ .Values.job.className }}
-    args: ["--input", "./README.txt"]
+    args: {{ .Values.job.args }}
     parallelism: {{ .Values.job.parallelism }}
     restartPolicy: {{ .Values.job.restartPolicy }}
+{{- if .Values.job.savepointsDir }}
+    savepointsDir: {{ toYaml .Values.job.savepointsDir }}
+{{- end }}
+{{- if .Values.job.hadoopConfig }}
+    hadoopConfig:
+{{ toYaml .Values.job.hadoopConfig | indent 6}}
+{{- end }}
+{{- if .Values.job.gcpConfig }}
+    gcpConfig:
+{{ toYaml .Values.job.gcpConfig | indent 6}}
+{{- end }}
 {{- if .Values.job.volumes }}
     volumes:
 {{ toYaml .Values.job.volumes | indent 6}}


### PR DESCRIPTION
related-issue: #367 

- Added savepointsDir, hadoopConfig, gcpConfig configs to flinkjobcluster helm chart.
- Fixed the job.args configuration from previously hardcoded value.