### PR TITLE
make the webhook expire days longer

### DIFF
--- a/helm-chart/flink-operator/templates/generate-cert.yaml
+++ b/helm-chart/flink-operator/templates/generate-cert.yaml
@@ -35,7 +35,7 @@ data:
     openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Admission Controller Webhook CA"
     openssl genrsa -out ${tmpdir}/server-key.pem 2048
     openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -config ${tmpdir}/csr.conf \
-        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out ${tmpdir}/server-cert.pem
+        | openssl x509 -days 3650 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out ${tmpdir}/server-cert.pem
     serverCert="$(openssl base64 -A -in ${tmpdir}/server-cert.pem)"
     if [[ -z ${serverCert} ]]; then
         echo "ERROR: The signed certificate did not appear." >&2


### PR DESCRIPTION
Fix the issue [356](https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/356)

We should make the expire days longer, the default expires days is 30, we change it to 3650.