### PR TITLE
Resolve CRD issue in Kubernetes v1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.4 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen


### PR DESCRIPTION
A new version of controller-gen that solves the issue (#266 #311 #338) has been released, but it is causing another issue https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/311#issuecomment-736597016. 

How about changing the controller-gen version to 0.2.4 until the CRD version is changed to v1 and the k8s.io domain problem is resolved.