### PR TITLE
Fix job recovery and savepoint bug

### DIFF
--- a/controllers/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster_reconciler.go
@@ -521,7 +521,7 @@ func (reconciler *ClusterReconciler) reconcileJob() (ctrl.Result, error) {
 			shouldTakeSavepont, savepointTriggerReason := reconciler.shouldTakeSavepoint()
 			if shouldTakeSavepont {
 				err = reconciler.updateSavepointTriggerTimeStatus()
-				if err != nil {
+				if err == nil {
 					newSavepointStatus, _ = reconciler.takeSavepointAsync(jobID, savepointTriggerReason)
 				}
 			}
@@ -997,6 +997,7 @@ func (reconciler *ClusterReconciler) updateStatusForNewJob() error {
 		clusterClone.Status.Components.Job = newJobStatus
 	}
 	var fromSavepoint = getFromSavepoint(desiredJob.Spec)
+	newJobStatus.ID = ""
 	newJobStatus.State = v1beta1.JobStatePending
 	newJobStatus.FromSavepoint = fromSavepoint
 	if newJobStatus.SavepointLocation != "" {


### PR DESCRIPTION
* Job recovery bug
When job manager fails and job state falls to `Lost`, job is not properly recovered.
The job is resubmitted, but the previous job ID is not cleared, so it is considered an unexpected job and is canceled. 

* Savepoint bug
Savepoint is not triggered properly.

Resolves #398 