### PR TITLE
Fix from savepoint typo in docs

### DIFF
--- a/docs/savepoints_guide.md
+++ b/docs/savepoints_guide.md
@@ -16,7 +16,7 @@ metadata:
 spec:
   ...
   job:
-    fromSavePoint: gs://my-bucket/savepoints/savepoint-123
+    fromSavepoint: gs://my-bucket/savepoints/savepoint-123
     allowNonRestoredState: false
     ...
 ```


### PR DESCRIPTION
Change `FixSavePoint` -> `FixSavepoint` in `savepoints_guide.md` docs.
related issue: https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/395#issuecomment-764472587