### PR TITLE
Fix a typo in helm-chart/flink-job-cluster default values

### DIFF
--- a/helm-chart/flink-job-cluster/values.yaml
+++ b/helm-chart/flink-job-cluster/values.yaml
@@ -51,7 +51,7 @@ job:
   jarFile: ./examples/streaming/WordCount.jar 
   className: org.apache.flink.streaming.examples.wordcount.WordCount
   args: ["--input", "./README.txt"]
-  paralellism: 2
+  parallelism: 2
   restartPolicy: Never
   
   # Mount an EmptyDir so the InitContainer can store its JarFile in the specific path for the job to execute, only needed when initContainer is enabled.


### PR DESCRIPTION
When deploying the chart with default values you see an error like this:

> Helm upgrade failed: failed to create resource: FlinkCluster.flinkoperator.k8s.io "flink-flink-cluster-flink-job-cluster" is invalid: spec.job.parallelism: Invalid value: "null": spec.job.parallelism in body must be of type integer: "null"

Fixing the typo here resolves the issue.