### PR TITLE
adds connection timeout to job submitter

### DIFF
--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -57,8 +57,8 @@ function check_jm_ready() {
 
     echo_log "Checking job manager to be ready. Will check success of ${REQUIRED_SUCCESS_NUMBER} API calls for stable job submission." "job_check_log"
     for ((i = 1; i <= MAX_RETRY; i++)); do
-        echo_log "curl -sS \"http://${FLINK_JM_ADDR}/jobs\"" "job_check_log"
-        if curl -sS "http://${FLINK_JM_ADDR}/jobs" 2>&1 | tee -a job_check_log; then
+        echo_log "curl -sS --connect-timeout 5 \"http://${FLINK_JM_ADDR}/jobs\"" "job_check_log"
+        if curl -sS --connect-timeout 5 "http://${FLINK_JM_ADDR}/jobs" 2>&1 | tee -a job_check_log; then
             ((success_count++))
             echo_log "\nSuccess ${success_count}/${REQUIRED_SUCCESS_NUMBER}" "job_check_log"
             if ((success_count < REQUIRED_SUCCESS_NUMBER)); then


### PR DESCRIPTION
Hi all,

While experimenting with the Flink operator, I experienced some occasional glitches when the very first `curl` done by the job submitter hangs for a very long time before retrying, instead of the usual 5 seconds. It then eventually times out, although this long pause has an unnecessary impact on the deployment duration.

```sh
Checking job manager to be ready. Will check success of 2 API calls for stable job submission.
curl -sS "http://fandom-analytics-metrics-computer-jobmanager:8081/jobs"
```

I believe this happens when the job submitter calls `curl` before the job manager is even started, in which case we're getting connection timeout (after 120s) instead of an immediate "connection refused".

After adding the `--connect-timeout 5`, all deployment continued to work successfully, and I never experienced again the hanging behaviour mentioned above.

Let me know your thoughts
