### PR TITLE
Update flink-operator.yaml for helm resource-polic

### DIFF
--- a/helm-chart/flink-operator/templates/flink-operator.yaml
+++ b/helm-chart/flink-operator/templates/flink-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    annotations:
+      "helm.sh/resource-policy": keep
     control-plane: controller-manager
   name: {{ .Values.flinkOperatorNamespace.name }}
 ---


### PR DESCRIPTION
When you set the operator namespace to an existing one, helm delete will recycle the namespace, which is a dangerous operation and will cause all the resources of the namespace to be recycled.