### PR TITLE
Fixed link to job cluster Helm Chart guide

### DIFF
--- a/helm-chart/flink-job-cluster/README.md
+++ b/helm-chart/flink-job-cluster/README.md
@@ -1,3 +1,3 @@
 # Helm Chart for Flink Job Cluster
 
-Please follow the Flink job cluster Helm Chart [guide](docs/flink_job_cluster_guide) to deploy the helm chart.
+Please follow the Flink job cluster Helm Chart [guide](../../docs/flink_job_cluster_guide) to deploy the helm chart.

--- a/helm-chart/flink-job-cluster/README.md
+++ b/helm-chart/flink-job-cluster/README.md
@@ -1,3 +1,3 @@
 # Helm Chart for Flink Job Cluster
 
-Please follow the Flink job cluster Helm Chart [guide](../../docs/flink_job_cluster_guide) to deploy the helm chart.
+Please follow the Flink job cluster Helm Chart [guide](/docs/flink_job_cluster_guide) to deploy the helm chart.


### PR DESCRIPTION
There's a [broken link](https://github.com/marcomicera/flink-on-k8s-operator/blob/master/helm-chart/flink-job-cluster/README.md) to the Flink job cluster Helm Chart guide.