### PR TITLE
Add required fields to job cluster samples

### DIFF
--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -20,6 +20,7 @@ spec:
   image:
     name: flink:1.8.2
   jobManager:
+    accessScope: Cluster
     ports:
       ui: 8081
     resources:
@@ -37,5 +38,6 @@ spec:
     className: org.apache.flink.streaming.examples.wordcount.WordCount
     args: ["--input", "./README.txt"]
     parallelism: 2
+    restartPolicy: Never
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"

--- a/config/samples/flinkoperator_v1beta1_remotejobjar.yaml
+++ b/config/samples/flinkoperator_v1beta1_remotejobjar.yaml
@@ -24,6 +24,7 @@ spec:
   image:
     name: flink:1.8.2
   jobManager:
+    accessScope: Cluster
     ports:
       ui: 8081
     resources:
@@ -53,6 +54,7 @@ spec:
           - "cp"
           - "gs://my-bucket/wordcount.jar"
           - "/cache/wordcount.jar"
+    restartPolicy: Never
   gcpConfig:
     serviceAccount:
       secretName: "gcp-service-account"


### PR DESCRIPTION
I found `flinkoperator_v1beta1_flinkjobcluster.yaml` and `flinkoperator_v1beta1_remotejobjar.yaml` missed required fields for v1beta1 `flinkclusters.flinkoperator.k8s.io`.